### PR TITLE
fix(docker): use numeric uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ WORKDIR /app
 
 COPY --from=build /out/llm-proxy /app/llm-proxy
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -g 65532 -S app && adduser -u 65532 -S app -G app
 
-USER app
+USER 65532
 
 ENTRYPOINT ["/app/llm-proxy"]

--- a/charts/llm-proxy/Chart.yaml
+++ b/charts/llm-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: llm-proxy
 description: Helm chart for deploying the agyn LLM Proxy service.
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 home: https://github.com/agynio/llm-proxy
 sources:
   - https://github.com/agynio/llm-proxy


### PR DESCRIPTION
## Summary
- switch Dockerfile to a numeric uid/gid for the app user
- bump llm-proxy chart version to 0.1.2

## Testing
- DOCKER_BUILDKIT=1 docker build .
- helm dependency build charts/llm-proxy
- helm lint charts/llm-proxy
- helm template test charts/llm-proxy

Closes #7