### PR TITLE
fix: start http listener before enroll

### DIFF
--- a/charts/llm-proxy/Chart.yaml
+++ b/charts/llm-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: llm-proxy
 description: Helm chart for deploying the agyn LLM Proxy service.
 type: application
-version: 0.1.3
-appVersion: 0.1.3
+version: 0.1.4
+appVersion: 0.1.4
 home: https://github.com/agynio/llm-proxy
 sources:
   - https://github.com/agynio/llm-proxy

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -99,6 +99,13 @@ func run() error {
 
 	errCh := make(chan error, 2)
 
+	go func() {
+		log.Printf("llm-proxy listening on %s", cfg.ListenAddress)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("http server stopped: %w", err)
+		}
+	}()
+
 	if cfg.ZitiEnabled {
 		enrollmentCtx, cancel := context.WithTimeout(ctx, cfg.ZitiEnrollmentTimeout)
 		defer cancel()
@@ -138,13 +145,6 @@ func run() error {
 			}
 		}()
 	}
-
-	go func() {
-		log.Printf("llm-proxy listening on %s", cfg.ListenAddress)
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- fmt.Errorf("http server stopped: %w", err)
-		}
-	}()
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Summary
- start the standard HTTP listener before ziti enrollment to keep liveness probes healthy
- bump Helm chart version to 0.1.4

## Testing
- go test ./...
- go vet ./...
- helm lint charts/llm-proxy

Closes #11