### PR TITLE
fix(proxy): correct provider response path

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -193,7 +193,7 @@ func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.Resolv
 }
 
 func buildProviderRequest(ctx context.Context, endpoint string, token string, body []byte, stream bool) (*http.Request, error) {
-	url := endpoint + "/v1/responses"
+	url := strings.TrimRight(endpoint, "/") + "/responses"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -64,7 +64,7 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	providerCalled := false
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		providerCalled = true
-		if r.URL.Path != "/v1/responses" {
+		if r.URL.Path != "/responses" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
 		if r.Header.Get("Authorization") != "Bearer provider-token" {


### PR DESCRIPTION
## Summary
- update provider request path to use /responses
- align handler test with new upstream path

## Testing
- buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go vet ./...
- go build ./...
- go test ./...

Fixes #18