### PR TITLE
fix(proxy): use provider endpoint verbatim

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -193,7 +193,7 @@ func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.Resolv
 }
 
 func buildProviderRequest(ctx context.Context, endpoint string, token string, body []byte, stream bool) (*http.Request, error) {
-	url := strings.TrimRight(endpoint, "/") + "/responses"
+	url := endpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -98,7 +98,7 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	defer provider.Close()
 
 	llmClient := &fakeLLMClient{resp: &llmv1.ResolveModelResponse{
-		Endpoint:       provider.URL,
+		Endpoint:       provider.URL + "/responses",
 		Token:          "provider-token",
 		RemoteName:     "remote-model",
 		OrganizationId: "org-1",
@@ -164,7 +164,7 @@ func TestHandlerForwardStream(t *testing.T) {
 	defer provider.Close()
 
 	llmClient := &fakeLLMClient{resp: &llmv1.ResolveModelResponse{
-		Endpoint:       provider.URL,
+		Endpoint:       provider.URL + "/responses",
 		Token:          "provider-token",
 		RemoteName:     "remote-model",
 		OrganizationId: "org-1",
@@ -203,7 +203,7 @@ func TestHandlerForbidden(t *testing.T) {
 	defer provider.Close()
 
 	llmClient := &fakeLLMClient{resp: &llmv1.ResolveModelResponse{
-		Endpoint:       provider.URL,
+		Endpoint:       provider.URL + "/responses",
 		Token:          "provider-token",
 		RemoteName:     "remote-model",
 		OrganizationId: "org-1",

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -26,7 +26,7 @@ const (
 	defaultLLMAddr           = "llm:50051"
 	setupTimeout             = 30 * time.Second
 	apiTokenName             = "e2e-llm-proxy"
-	llmProviderEndpoint      = "https://testllm.dev/v1/org/agynio/suite/agn"
+	llmProviderEndpoint      = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
 )
 
 var (


### PR DESCRIPTION
## Summary
- use provider endpoint as-is when building upstream request URLs
- update proxy handler tests to provide full endpoint paths
- adjust e2e provider endpoint fixture to include /responses

## Testing
- buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go vet ./...
- go build ./...
- go test ./...

Fixes #18