### PR TITLE
fix(docker): set numeric runtime uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ WORKDIR /app
 
 COPY --from=build /out/llm-proxy /app/llm-proxy
 
-RUN addgroup -g 65532 -S app && adduser -u 65532 -S app -G app
+RUN addgroup -S app && adduser -S app -G app
 
-USER 65532
+USER 100
 
 ENTRYPOINT ["/app/llm-proxy"]


### PR DESCRIPTION
## Summary
- set the runtime USER to UID 100 for non-root verification
- revert app user creation to default Alpine system UID/GID

## Testing
- buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go vet ./...
- go build ./...
- go test ./...

Fixes #18