### PR TITLE
fix(auth): accept x-api-key header

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/agynio/llm-proxy/internal/apitokenresolver"
 	"github.com/agynio/llm-proxy/internal/httpauth"
@@ -26,7 +27,13 @@ func Middleware(zitiResolver IdentityResolver, apiTokenResolver BearerTokenResol
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, err := resolveIdentity(r.Context(), r.Header.Get("Authorization"), zitiResolver, apiTokenResolver)
+			ctx, err := resolveIdentity(
+				r.Context(),
+				r.Header.Get("Authorization"),
+				r.Header.Get("x-api-key"),
+				zitiResolver,
+				apiTokenResolver,
+			)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
@@ -37,7 +44,7 @@ func Middleware(zitiResolver IdentityResolver, apiTokenResolver BearerTokenResol
 	}
 }
 
-func resolveIdentity(ctx context.Context, authHeader string, zitiResolver IdentityResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
+func resolveIdentity(ctx context.Context, authHeader string, apiKeyHeader string, zitiResolver IdentityResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
 	sourceIdentity, ok := ziticonn.SourceIdentityFromContext(ctx)
 	if ok {
 		if zitiResolver == nil {
@@ -51,6 +58,10 @@ func resolveIdentity(ctx context.Context, authHeader string, zitiResolver Identi
 	}
 
 	accessToken, ok := httpauth.ExtractBearerToken(authHeader)
+	if !ok {
+		accessToken = strings.TrimSpace(apiKeyHeader)
+		ok = accessToken != ""
+	}
 	if !ok {
 		return ctx, errors.New("authorization required")
 	}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agynio/llm-proxy/internal/identity"
+)
+
+type stubBearerResolver struct {
+	called    bool
+	lastToken string
+	result    identity.ResolvedIdentity
+}
+
+func (s *stubBearerResolver) ResolveFromToken(_ context.Context, accessToken string) (identity.ResolvedIdentity, error) {
+	s.called = true
+	s.lastToken = accessToken
+	return s.result, nil
+}
+
+func TestResolveIdentityUsesAPIKeyHeader(t *testing.T) {
+	resolver := &stubBearerResolver{result: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
+
+	ctx, err := resolveIdentity(context.Background(), "", "agyn_api", nil, resolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !resolver.called {
+		t.Fatalf("expected resolver to be called")
+	}
+	if resolver.lastToken != "agyn_api" {
+		t.Fatalf("expected token %q, got %q", "agyn_api", resolver.lastToken)
+	}
+	resolved, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected identity in context")
+	}
+	if resolved.IdentityID != "user-1" {
+		t.Fatalf("expected identity id %q, got %q", "user-1", resolved.IdentityID)
+	}
+}
+
+func TestResolveIdentityPrefersAuthorizationHeader(t *testing.T) {
+	resolver := &stubBearerResolver{result: identity.ResolvedIdentity{IdentityID: "user-2", IdentityType: identity.IdentityTypeUser}}
+
+	ctx, err := resolveIdentity(context.Background(), "Bearer agyn_auth", "agyn_api", nil, resolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !resolver.called {
+		t.Fatalf("expected resolver to be called")
+	}
+	if resolver.lastToken != "agyn_auth" {
+		t.Fatalf("expected token %q, got %q", "agyn_auth", resolver.lastToken)
+	}
+	resolved, ok := identity.IdentityFromContext(ctx)
+	if !ok {
+		t.Fatalf("expected identity in context")
+	}
+	if resolved.IdentityID != "user-2" {
+		t.Fatalf("expected identity id %q, got %q", "user-2", resolved.IdentityID)
+	}
+}
+
+func TestResolveIdentityRejectsBlankAPIKey(t *testing.T) {
+	_, err := resolveIdentity(context.Background(), "", " \t ", nil, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "authorization required" {
+		t.Fatalf("expected authorization required error, got %q", err.Error())
+	}
+}
+
+func TestResolveIdentityRejectsAPIKeyWithoutPrefix(t *testing.T) {
+	_, err := resolveIdentity(context.Background(), "", "api_token", nil, nil)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "unsupported bearer token" {
+		t.Fatalf("expected unsupported bearer token error, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- accept x-api-key as an auth header input
- fall back to x-api-key when bearer token is absent

## Testing
- buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go vet ./...
- go build ./...
- go test ./...

Fixes #36