### PR TITLE
feat(proxy): add metering records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             --path agynio/api/llm/v1 \
             --path agynio/api/users/v1 \
             --path agynio/api/authorization/v1 \
+            --path agynio/api/metering/v1 \
             --path agynio/api/ziti_management/v1 \
             --path agynio/api/identity/v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN buf generate buf.build/agynio/api \
   --path agynio/api/llm/v1 \
   --path agynio/api/users/v1 \
   --path agynio/api/authorization/v1 \
+  --path agynio/api/metering/v1 \
   --path agynio/api/ziti_management/v1 \
   --path agynio/api/identity/v1
 

--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -15,6 +15,7 @@ import (
 
 	authorizationv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/authorization/v1"
 	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
+	meteringv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/metering/v1"
 	usersv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/users/v1"
 	zitimgmtv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/llm-proxy/internal/apitokenresolver"
@@ -56,6 +57,7 @@ func run() error {
 	llmClient := mustClient(cfg.LLMServiceAddress, "llm", llmv1.NewLLMServiceClient, &cleanup)
 	authzClient := mustClient(cfg.AuthorizationServiceAddress, "authorization", authorizationv1.NewAuthorizationServiceClient, &cleanup)
 	usersClient := mustClient(cfg.UsersServiceAddress, "users", usersv1.NewUsersServiceClient, &cleanup)
+	meteringClient := mustClient(cfg.MeteringServiceAddress, "metering", meteringv1.NewMeteringServiceClient, &cleanup)
 
 	apiTokenResolver := apitokenresolver.NewResolver(usersClient)
 
@@ -77,7 +79,7 @@ func run() error {
 		zitiResolver = zitiMgmtClient
 	}
 
-	proxyHandler := proxy.NewHandler(llmClient, authzClient, &http.Client{})
+	proxyHandler := proxy.NewHandler(llmClient, authzClient, meteringClient, &http.Client{})
 	handler := auth.Middleware(zitiResolver, apiTokenResolver)(proxyHandler)
 
 	connContext := func(ctx context.Context, conn net.Conn) context.Context {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -56,6 +56,7 @@ functions:
                     --path agynio/api/llm/v1 \
                     --path agynio/api/users/v1 \
                     --path agynio/api/authorization/v1 \
+                    --path agynio/api/metering/v1 \
                     --path agynio/api/ziti_management/v1 \
                     --path agynio/api/identity/v1
                   exec go run ./cmd/llm-proxy
@@ -150,6 +151,7 @@ pipelines:
           --path agynio/api/llm/v1 \
           --path agynio/api/users/v1 \
           --path agynio/api/authorization/v1 \
+          --path agynio/api/metering/v1 \
           --path agynio/api/ziti_management/v1 \
           --path agynio/api/identity/v1 \
           --path agynio/api/organizations/v1 && go test -v -count=1 -tags e2e ./test/e2e/'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	defaultListenAddress         = ":8080"
-	defaultLLMServiceAddress     = "llm:50051"
-	defaultUsersServiceAddress   = "users:50051"
-	defaultAuthzServiceAddress   = "authorization:50051"
-	defaultZitiManagementAddress = "ziti-management:50051"
-	defaultZitiLeaseInterval     = 2 * time.Minute
-	defaultZitiEnrollmentTimeout = 5 * time.Minute
+	defaultListenAddress          = ":8080"
+	defaultLLMServiceAddress      = "llm:50051"
+	defaultUsersServiceAddress    = "users:50051"
+	defaultAuthzServiceAddress    = "authorization:50051"
+	defaultMeteringServiceAddress = "metering:50051"
+	defaultZitiManagementAddress  = "ziti-management:50051"
+	defaultZitiLeaseInterval      = 2 * time.Minute
+	defaultZitiEnrollmentTimeout  = 5 * time.Minute
 )
 
 type Config struct {
@@ -23,6 +24,7 @@ type Config struct {
 	LLMServiceAddress           string
 	UsersServiceAddress         string
 	AuthorizationServiceAddress string
+	MeteringServiceAddress      string
 	ZitiManagementAddress       string
 	ZitiEnabled                 bool
 	ZitiLeaseRenewalInterval    time.Duration
@@ -56,6 +58,7 @@ func LoadConfigFromEnv() (*Config, error) {
 		LLMServiceAddress:           envOrDefault("LLM_SERVICE_ADDRESS", defaultLLMServiceAddress),
 		UsersServiceAddress:         envOrDefault("USERS_SERVICE_ADDRESS", defaultUsersServiceAddress),
 		AuthorizationServiceAddress: envOrDefault("AUTHORIZATION_SERVICE_ADDRESS", defaultAuthzServiceAddress),
+		MeteringServiceAddress:      envOrDefault("METERING_SERVICE_ADDRESS", defaultMeteringServiceAddress),
 		ZitiManagementAddress:       envOrDefault("ZITI_MANAGEMENT_ADDRESS", defaultZitiManagementAddress),
 		ZitiEnabled:                 zitiEnabled,
 		ZitiLeaseRenewalInterval:    zitiLeaseRenewalInterval,

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -185,9 +185,7 @@ func (h *Handler) forwardResponse(w http.ResponseWriter, req *http.Request, meta
 		h.recordMetering(meta, nil, meteringStatusSuccess)
 		return
 	}
-	var usagePtr *usageCounts
-	usagePtr = &usage
-	h.recordMetering(meta, usagePtr, meteringStatusSuccess)
+	h.recordMetering(meta, &usage, meteringStatusSuccess)
 }
 
 func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *http.Request, protocol llmv1.Protocol, meta meteringMetadata) {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -44,22 +45,26 @@ type AuthorizationChecker interface {
 }
 
 type Handler struct {
-	llmClient   ModelResolver
-	authzClient AuthorizationChecker
-	client      *http.Client
+	llmClient      ModelResolver
+	authzClient    AuthorizationChecker
+	meteringClient MeteringRecorder
+	client         *http.Client
 }
 
-func NewHandler(llmClient ModelResolver, authzClient AuthorizationChecker, client *http.Client) http.Handler {
+func NewHandler(llmClient ModelResolver, authzClient AuthorizationChecker, meteringClient MeteringRecorder, client *http.Client) http.Handler {
 	if llmClient == nil {
 		panic("llm client is required")
 	}
 	if authzClient == nil {
 		panic("authorization client is required")
 	}
+	if meteringClient == nil {
+		panic("metering client is required")
+	}
 	if client == nil {
 		panic("http client is required")
 	}
-	return &Handler{llmClient: llmClient, authzClient: authzClient, client: client}
+	return &Handler{llmClient: llmClient, authzClient: authzClient, meteringClient: meteringClient, client: client}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +84,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeProxyError(w, ErrMissingIdentity)
 		return
 	}
+	threadID := strings.TrimSpace(r.Header.Get("x-agyn-thread-id"))
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 	body, err := io.ReadAll(r.Body)
@@ -115,6 +121,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	meteringMeta := meteringMetadata{
+		callID:    uuid.NewString(),
+		orgID:     providerConfig.organizationID,
+		modelID:   modelID,
+		modelName: providerConfig.remoteName,
+		threadID:  threadID,
+		identity:  resolvedIdentity,
+	}
+
 	updatedBody, err := updateRequestPayload(payload, providerConfig.remoteName, stream)
 	if err != nil {
 		writeProxyError(w, err)
@@ -129,32 +144,56 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if stream {
-		h.streamResponse(w, r, providerReq)
+		h.streamResponse(w, r, providerReq, expectedProtocol, meteringMeta)
 		return
 	}
 
-	h.forwardResponse(w, providerReq)
+	h.forwardResponse(w, providerReq, meteringMeta)
 }
 
-func (h *Handler) forwardResponse(w http.ResponseWriter, req *http.Request) {
+func (h *Handler) forwardResponse(w http.ResponseWriter, req *http.Request, meta meteringMetadata) {
 	resp, err := h.client.Do(req)
 	if err != nil {
+		h.recordMetering(meta, nil, meteringStatusFailed)
 		writeProxyError(w, fmt.Errorf("send request: %w", err))
 		return
 	}
 	log.Printf("proxy: upstream response status=%d", resp.StatusCode)
 	defer closeResponseBody(resp.Body)
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		h.recordMetering(meta, nil, meteringStatusFailed)
+		writeProxyError(w, fmt.Errorf("read response: %w", err))
+		return
+	}
+
 	copyHeaders(w.Header(), resp.Header, nil)
 	w.WriteHeader(resp.StatusCode)
-	if _, err := io.Copy(w, resp.Body); err != nil {
+	if _, err := w.Write(body); err != nil {
 		log.Printf("proxy: forward response failed: %v", err)
 	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		h.recordMetering(meta, nil, meteringStatusFailed)
+		return
+	}
+
+	usage, err := parseUsageFromPayload(body)
+	if err != nil {
+		log.Printf("proxy: metering usage parse failed: %v", err)
+		h.recordMetering(meta, nil, meteringStatusSuccess)
+		return
+	}
+	var usagePtr *usageCounts
+	usagePtr = &usage
+	h.recordMetering(meta, usagePtr, meteringStatusSuccess)
 }
 
-func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *http.Request) {
+func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *http.Request, protocol llmv1.Protocol, meta meteringMetadata) {
 	resp, err := h.client.Do(req)
 	if err != nil {
+		h.recordMetering(meta, nil, meteringStatusFailed)
 		writeProxyError(w, fmt.Errorf("send request: %w", err))
 		return
 	}
@@ -165,11 +204,21 @@ func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *ht
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		_, _ = io.Copy(w, resp.Body)
+		h.recordMetering(meta, nil, meteringStatusFailed)
 		return
 	}
-	if err := streamToClient(r.Context(), w, resp.Body); err != nil {
+	usage, err := streamToClient(r.Context(), w, resp.Body, protocol)
+	if err != nil {
 		log.Printf("proxy: stream response failed: %v", err)
+		h.recordMetering(meta, nil, meteringStatusFailed)
+		return
 	}
+	if usage == nil {
+		log.Printf("proxy: metering usage missing for streaming response")
+		h.recordMetering(meta, nil, meteringStatusSuccess)
+		return
+	}
+	h.recordMetering(meta, usage, meteringStatusSuccess)
 }
 
 func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.ResolvedIdentity, organizationID string) error {
@@ -416,28 +465,58 @@ func closeResponseBody(body io.Closer) {
 	}
 }
 
-func streamToClient(ctx context.Context, w http.ResponseWriter, body io.Reader) error {
+func streamToClient(ctx context.Context, w http.ResponseWriter, body io.Reader, protocol llmv1.Protocol) (*usageCounts, error) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		return errors.New("streaming unsupported")
+		return nil, errors.New("streaming unsupported")
 	}
-	buffer := make([]byte, 32*1024)
+	reader := bufio.NewReader(body)
+	var usage *usageCounts
+	var eventType string
+	var dataLines []string
+
+	processEvent := func() {
+		if len(dataLines) == 0 {
+			eventType = ""
+			return
+		}
+		data := strings.Join(dataLines, "\n")
+		parsed, matched, err := parseUsageFromEvent(protocol, eventType, data)
+		if err != nil {
+			log.Printf("proxy: metering usage parse failed: %v", err)
+		} else if matched {
+			usage = &parsed
+		}
+		eventType = ""
+		dataLines = nil
+	}
+
 	for {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
-		n, err := body.Read(buffer)
-		if n > 0 {
-			if _, writeErr := w.Write(buffer[:n]); writeErr != nil {
-				return writeErr
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			if _, writeErr := w.Write([]byte(line)); writeErr != nil {
+				return nil, writeErr
 			}
 			flusher.Flush()
+
+			trimmed := strings.TrimRight(line, "\r\n")
+			if trimmed == "" {
+				processEvent()
+			} else if strings.HasPrefix(trimmed, "event:") {
+				eventType = strings.TrimSpace(strings.TrimPrefix(trimmed, "event:"))
+			} else if strings.HasPrefix(trimmed, "data:") {
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(trimmed, "data:")))
+			}
 		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil
+				processEvent()
+				return usage, nil
 			}
-			return err
+			return usage, err
 		}
 	}
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	authorizationv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/authorization/v1"
 	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
+	meteringv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/metering/v1"
 	"github.com/agynio/llm-proxy/internal/identity"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -46,8 +47,14 @@ func (f *fakeAuthzClient) Check(_ context.Context, req *authorizationv1.CheckReq
 	return f.resp, nil
 }
 
+type fakeMeteringClient struct{}
+
+func (f *fakeMeteringClient) Record(_ context.Context, _ *meteringv1.RecordRequest, _ ...grpc.CallOption) (*meteringv1.RecordResponse, error) {
+	return &meteringv1.RecordResponse{}, nil
+}
+
 func TestHandlerRejectsMissingIdentity(t *testing.T) {
-	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, http.DefaultClient)
+	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, &fakeMeteringClient{}, http.DefaultClient)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"`+uuid.NewString()+`"}`))
 	resp := httptest.NewRecorder()
@@ -107,7 +114,7 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
 
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":false}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -174,7 +181,7 @@ func TestHandlerForwardStream(t *testing.T) {
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -246,7 +253,7 @@ func TestHandlerForwardAnthropicMessages(t *testing.T) {
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
 
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":false}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", strings.NewReader(body))
@@ -296,7 +303,7 @@ func TestHandlerMessagesWithoutAnthropicVersion(t *testing.T) {
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
 
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":false}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", strings.NewReader(body))
@@ -351,7 +358,7 @@ func TestHandlerMessagesStream(t *testing.T) {
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", strings.NewReader(body))
@@ -395,7 +402,7 @@ func TestHandlerProtocolMismatchMessagesWithResponses(t *testing.T) {
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
 
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `"}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", strings.NewReader(body))
@@ -432,7 +439,7 @@ func TestHandlerProtocolMismatchResponsesWithAnthropic(t *testing.T) {
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
 
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `"}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -469,7 +476,7 @@ func TestHandlerUnsupportedAuthMethod(t *testing.T) {
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
 
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `"}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -504,7 +511,7 @@ func TestHandlerForbidden(t *testing.T) {
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: false}}
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `"}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -520,7 +527,7 @@ func TestHandlerForbidden(t *testing.T) {
 }
 
 func TestHandlerInvalidBody(t *testing.T) {
-	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, http.DefaultClient)
+	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, &fakeMeteringClient{}, http.DefaultClient)
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader("{"))
 	ctx := identity.WithIdentity(req.Context(), identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser})
@@ -535,7 +542,7 @@ func TestHandlerInvalidBody(t *testing.T) {
 }
 
 func TestHandlerRouteHandling(t *testing.T) {
-	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, http.DefaultClient)
+	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, &fakeMeteringClient{}, http.DefaultClient)
 
 	getReq := httptest.NewRequest(http.MethodGet, "http://example.com/v1/responses", nil)
 	getResp := httptest.NewRecorder()
@@ -571,7 +578,7 @@ func TestHandlerRouteHandling(t *testing.T) {
 func TestHandlerGRPCErrorMapping(t *testing.T) {
 	modelID := uuid.New()
 	llmClient := &fakeLLMClient{err: status.Error(codes.NotFound, "missing")}
-	handler := NewHandler(llmClient, &fakeAuthzClient{}, http.DefaultClient)
+	handler := NewHandler(llmClient, &fakeAuthzClient{}, &fakeMeteringClient{}, http.DefaultClient)
 
 	body := `{"model":"` + modelID.String() + `"}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -622,7 +629,7 @@ func TestHandlerProviderErrorForwardingNonStream(t *testing.T) {
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":false}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -658,7 +665,7 @@ func TestHandlerProviderErrorForwardingStream(t *testing.T) {
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
 	}}
 	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
-	handler := NewHandler(llmClient, authzClient, provider.Client())
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
 
 	body := `{"model":"` + modelID.String() + `","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
@@ -677,7 +684,7 @@ func TestHandlerProviderErrorForwardingStream(t *testing.T) {
 }
 
 func TestHandlerBodyTooLarge(t *testing.T) {
-	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, http.DefaultClient)
+	handler := NewHandler(&fakeLLMClient{}, &fakeAuthzClient{}, &fakeMeteringClient{}, http.DefaultClient)
 
 	oversize := strings.Repeat("a", int(maxRequestBodySize)+1)
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(oversize))

--- a/internal/proxy/metering.go
+++ b/internal/proxy/metering.go
@@ -132,10 +132,6 @@ func parseUsageFromEvent(protocol llmv1.Protocol, eventType string, data string)
 }
 
 func (h *Handler) recordMetering(meta meteringMetadata, usage *usageCounts, status string) {
-	if h.meteringClient == nil {
-		return
-	}
-
 	records := buildUsageRecords(meta, usage, status)
 	if len(records) == 0 {
 		return

--- a/internal/proxy/metering.go
+++ b/internal/proxy/metering.go
@@ -1,0 +1,208 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
+	meteringv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/metering/v1"
+	"github.com/agynio/llm-proxy/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	meteringProducer         = "llm-proxy"
+	meteringMicroUnits int64 = 1_000_000
+
+	meteringStatusSuccess = "success"
+	meteringStatusFailed  = "failed"
+
+	meteringKindInput   = "input"
+	meteringKindCached  = "cached"
+	meteringKindOutput  = "output"
+	meteringKindRequest = "request"
+)
+
+type MeteringRecorder interface {
+	Record(ctx context.Context, req *meteringv1.RecordRequest, opts ...grpc.CallOption) (*meteringv1.RecordResponse, error)
+}
+
+type meteringMetadata struct {
+	callID    string
+	orgID     string
+	modelID   string
+	modelName string
+	threadID  string
+	identity  identity.ResolvedIdentity
+}
+
+type usageCounts struct {
+	inputTokens  int64
+	cachedTokens int64
+	outputTokens int64
+}
+
+type usageInfo struct {
+	InputTokens        int64 `json:"input_tokens"`
+	OutputTokens       int64 `json:"output_tokens"`
+	CachedTokens       int64 `json:"cached_tokens"`
+	InputTokensDetails *struct {
+		CachedTokens int64 `json:"cached_tokens"`
+	} `json:"input_tokens_details"`
+}
+
+type responseUsagePayload struct {
+	Usage *usageInfo `json:"usage"`
+}
+
+type openAICompletedPayload struct {
+	Response *responseUsagePayload `json:"response"`
+}
+
+type anthropicDeltaPayload struct {
+	Usage *usageInfo `json:"usage"`
+}
+
+func usageFromInfo(info *usageInfo) usageCounts {
+	cachedTokens := info.CachedTokens
+	if cachedTokens == 0 && info.InputTokensDetails != nil {
+		cachedTokens = info.InputTokensDetails.CachedTokens
+	}
+	return usageCounts{
+		inputTokens:  info.InputTokens,
+		cachedTokens: cachedTokens,
+		outputTokens: info.OutputTokens,
+	}
+}
+
+func parseUsageFromPayload(body []byte) (usageCounts, error) {
+	if len(body) == 0 {
+		return usageCounts{}, fmt.Errorf("usage payload is empty")
+	}
+
+	var payload responseUsagePayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return usageCounts{}, fmt.Errorf("parse usage payload: %w", err)
+	}
+	if payload.Usage == nil {
+		return usageCounts{}, fmt.Errorf("usage payload missing usage")
+	}
+	return usageFromInfo(payload.Usage), nil
+}
+
+func parseUsageFromEvent(protocol llmv1.Protocol, eventType string, data string) (usageCounts, bool, error) {
+	trimmed := strings.TrimSpace(data)
+	if trimmed == "" {
+		return usageCounts{}, false, nil
+	}
+
+	switch protocol {
+	case llmv1.Protocol_PROTOCOL_RESPONSES:
+		if eventType != "response.completed" {
+			return usageCounts{}, false, nil
+		}
+		var payload openAICompletedPayload
+		if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+			return usageCounts{}, true, fmt.Errorf("parse response.completed: %w", err)
+		}
+		if payload.Response == nil || payload.Response.Usage == nil {
+			return usageCounts{}, true, fmt.Errorf("response.completed missing usage")
+		}
+		return usageFromInfo(payload.Response.Usage), true, nil
+	case llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES:
+		if eventType != "message_delta" {
+			return usageCounts{}, false, nil
+		}
+		var payload anthropicDeltaPayload
+		if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+			return usageCounts{}, true, fmt.Errorf("parse message_delta: %w", err)
+		}
+		if payload.Usage == nil {
+			return usageCounts{}, true, fmt.Errorf("message_delta missing usage")
+		}
+		return usageFromInfo(payload.Usage), true, nil
+	default:
+		return usageCounts{}, false, nil
+	}
+}
+
+func (h *Handler) recordMetering(meta meteringMetadata, usage *usageCounts, status string) {
+	if h.meteringClient == nil {
+		return
+	}
+
+	records := buildUsageRecords(meta, usage, status)
+	if len(records) == 0 {
+		return
+	}
+
+	go func(records []*meteringv1.UsageRecord) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if _, err := h.meteringClient.Record(ctx, &meteringv1.RecordRequest{Records: records}); err != nil {
+			log.Printf("proxy: metering record failed: %v", err)
+		}
+	}(records)
+}
+
+func buildUsageRecords(meta meteringMetadata, usage *usageCounts, status string) []*meteringv1.UsageRecord {
+	if meta.callID == "" || meta.orgID == "" {
+		return nil
+	}
+
+	timestamp := timestamppb.New(time.Now().UTC())
+	baseLabels := map[string]string{
+		"resource_id":   meta.modelID,
+		"resource":      meta.modelName,
+		"identity_id":   meta.identity.IdentityID,
+		"identity_type": string(meta.identity.IdentityType),
+		"thread_id":     meta.threadID,
+	}
+
+	records := make([]*meteringv1.UsageRecord, 0, 4)
+
+	if status == meteringStatusSuccess && usage != nil {
+		records = append(records, newUsageRecord(meta, timestamp, meteringv1.Unit_UNIT_TOKENS, usage.inputTokens*meteringMicroUnits,
+			withLabels(baseLabels, map[string]string{"kind": meteringKindInput}), "input"))
+		if usage.cachedTokens > 0 {
+			records = append(records, newUsageRecord(meta, timestamp, meteringv1.Unit_UNIT_TOKENS, usage.cachedTokens*meteringMicroUnits,
+				withLabels(baseLabels, map[string]string{"kind": meteringKindCached}), "cached"))
+		}
+		records = append(records, newUsageRecord(meta, timestamp, meteringv1.Unit_UNIT_TOKENS, usage.outputTokens*meteringMicroUnits,
+			withLabels(baseLabels, map[string]string{"kind": meteringKindOutput}), "output"))
+	}
+
+	requestLabels := withLabels(baseLabels, map[string]string{"kind": meteringKindRequest, "status": status})
+	records = append(records, newUsageRecord(meta, timestamp, meteringv1.Unit_UNIT_COUNT, meteringMicroUnits, requestLabels, "request"))
+
+	return records
+}
+
+func newUsageRecord(meta meteringMetadata, timestamp *timestamppb.Timestamp, unit meteringv1.Unit, value int64, labels map[string]string, suffix string) *meteringv1.UsageRecord {
+	return &meteringv1.UsageRecord{
+		OrgId:          meta.orgID,
+		IdempotencyKey: fmt.Sprintf("%s-%s", meta.callID, suffix),
+		Producer:       meteringProducer,
+		Timestamp:      timestamp,
+		Labels:         labels,
+		Unit:           unit,
+		Value:          value,
+	}
+}
+
+func withLabels(base map[string]string, extra map[string]string) map[string]string {
+	labels := make(map[string]string, len(base)+len(extra))
+	for key, value := range base {
+		labels[key] = value
+	}
+	for key, value := range extra {
+		labels[key] = value
+	}
+	return labels
+}

--- a/internal/proxy/metering_test.go
+++ b/internal/proxy/metering_test.go
@@ -1,0 +1,33 @@
+package proxy
+
+import "testing"
+
+func TestParseUsageFromPayloadOpenAIUsage(t *testing.T) {
+	body := []byte(`{"usage":{"input_tokens":12,"output_tokens":34,"cached_tokens":5}}`)
+
+	usage, err := parseUsageFromPayload(body)
+	if err != nil {
+		t.Fatalf("parse usage payload: %v", err)
+	}
+	if usage.inputTokens != 12 {
+		t.Fatalf("expected input tokens 12, got %d", usage.inputTokens)
+	}
+	if usage.outputTokens != 34 {
+		t.Fatalf("expected output tokens 34, got %d", usage.outputTokens)
+	}
+	if usage.cachedTokens != 5 {
+		t.Fatalf("expected cached tokens 5, got %d", usage.cachedTokens)
+	}
+}
+
+func TestParseUsageFromPayloadCachedTokensZero(t *testing.T) {
+	body := []byte(`{"usage":{"input_tokens":7,"output_tokens":11,"cached_tokens":0}}`)
+
+	usage, err := parseUsageFromPayload(body)
+	if err != nil {
+		t.Fatalf("parse usage payload: %v", err)
+	}
+	if usage.cachedTokens != 0 {
+		t.Fatalf("expected cached tokens 0, got %d", usage.cachedTokens)
+	}
+}

--- a/internal/proxy/metering_test.go
+++ b/internal/proxy/metering_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
+	meteringv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/metering/v1"
 )
 
 func TestParseUsageFromPayloadOpenAIUsage(t *testing.T) {
@@ -115,4 +116,116 @@ func TestParseUsageFromEventUnknownProtocol(t *testing.T) {
 	if usage != (usageCounts{}) {
 		t.Fatalf("expected empty usage counts")
 	}
+}
+
+func TestUsageFromInfoCachedTokensTopLevel(t *testing.T) {
+	details := &struct {
+		CachedTokens int64 `json:"cached_tokens"`
+	}{CachedTokens: 4}
+	info := &usageInfo{InputTokens: 2, OutputTokens: 3, CachedTokens: 7, InputTokensDetails: details}
+
+	usage := usageFromInfo(info)
+	if usage.inputTokens != 2 {
+		t.Fatalf("expected input tokens 2, got %d", usage.inputTokens)
+	}
+	if usage.outputTokens != 3 {
+		t.Fatalf("expected output tokens 3, got %d", usage.outputTokens)
+	}
+	if usage.cachedTokens != 7 {
+		t.Fatalf("expected cached tokens 7, got %d", usage.cachedTokens)
+	}
+}
+
+func TestUsageFromInfoCachedTokensFallback(t *testing.T) {
+	details := &struct {
+		CachedTokens int64 `json:"cached_tokens"`
+	}{CachedTokens: 6}
+	info := &usageInfo{InputTokens: 5, OutputTokens: 8, CachedTokens: 0, InputTokensDetails: details}
+
+	usage := usageFromInfo(info)
+	if usage.cachedTokens != 6 {
+		t.Fatalf("expected cached tokens 6, got %d", usage.cachedTokens)
+	}
+}
+
+func TestBuildUsageRecordsSuccessWithCached(t *testing.T) {
+	meta := meteringMetadata{callID: "call-1", orgID: "org-1", modelID: "model-1", modelName: "model", threadID: "thread"}
+	usage := usageCounts{inputTokens: 10, cachedTokens: 2, outputTokens: 4}
+
+	records := buildUsageRecords(meta, &usage, meteringStatusSuccess)
+	if len(records) != 4 {
+		t.Fatalf("expected 4 records, got %d", len(records))
+	}
+	counts := recordKinds(records)
+	if counts[meteringKindInput] != 1 {
+		t.Fatalf("expected 1 input record, got %d", counts[meteringKindInput])
+	}
+	if counts[meteringKindCached] != 1 {
+		t.Fatalf("expected 1 cached record, got %d", counts[meteringKindCached])
+	}
+	if counts[meteringKindOutput] != 1 {
+		t.Fatalf("expected 1 output record, got %d", counts[meteringKindOutput])
+	}
+	if counts[meteringKindRequest] != 1 {
+		t.Fatalf("expected 1 request record, got %d", counts[meteringKindRequest])
+	}
+}
+
+func TestBuildUsageRecordsSuccessWithoutCached(t *testing.T) {
+	meta := meteringMetadata{callID: "call-1", orgID: "org-1", modelID: "model-1", modelName: "model", threadID: "thread"}
+	usage := usageCounts{inputTokens: 10, cachedTokens: 0, outputTokens: 4}
+
+	records := buildUsageRecords(meta, &usage, meteringStatusSuccess)
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	counts := recordKinds(records)
+	if counts[meteringKindCached] != 0 {
+		t.Fatalf("expected 0 cached records, got %d", counts[meteringKindCached])
+	}
+	if counts[meteringKindRequest] != 1 {
+		t.Fatalf("expected 1 request record, got %d", counts[meteringKindRequest])
+	}
+}
+
+func TestBuildUsageRecordsFailure(t *testing.T) {
+	meta := meteringMetadata{callID: "call-1", orgID: "org-1", modelID: "model-1", modelName: "model", threadID: "thread"}
+	usage := usageCounts{inputTokens: 10, cachedTokens: 2, outputTokens: 4}
+
+	records := buildUsageRecords(meta, &usage, meteringStatusFailed)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	record := records[0]
+	if record.Unit != meteringv1.Unit_UNIT_COUNT {
+		t.Fatalf("expected count unit, got %v", record.Unit)
+	}
+	if record.Labels["kind"] != meteringKindRequest {
+		t.Fatalf("expected request kind, got %q", record.Labels["kind"])
+	}
+	if record.Labels["status"] != meteringStatusFailed {
+		t.Fatalf("expected failed status, got %q", record.Labels["status"])
+	}
+}
+
+func TestBuildUsageRecordsGuard(t *testing.T) {
+	usage := usageCounts{inputTokens: 1, cachedTokens: 0, outputTokens: 1}
+
+	missingCall := meteringMetadata{orgID: "org-1"}
+	if records := buildUsageRecords(missingCall, &usage, meteringStatusSuccess); records != nil {
+		t.Fatalf("expected nil records for missing call ID")
+	}
+
+	missingOrg := meteringMetadata{callID: "call-1"}
+	if records := buildUsageRecords(missingOrg, &usage, meteringStatusSuccess); records != nil {
+		t.Fatalf("expected nil records for missing org ID")
+	}
+}
+
+func recordKinds(records []*meteringv1.UsageRecord) map[string]int {
+	counts := make(map[string]int)
+	for _, record := range records {
+		counts[record.Labels["kind"]]++
+	}
+	return counts
 }

--- a/internal/proxy/metering_test.go
+++ b/internal/proxy/metering_test.go
@@ -1,6 +1,10 @@
 package proxy
 
-import "testing"
+import (
+	"testing"
+
+	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
+)
 
 func TestParseUsageFromPayloadOpenAIUsage(t *testing.T) {
 	body := []byte(`{"usage":{"input_tokens":12,"output_tokens":34,"cached_tokens":5}}`)
@@ -29,5 +33,86 @@ func TestParseUsageFromPayloadCachedTokensZero(t *testing.T) {
 	}
 	if usage.cachedTokens != 0 {
 		t.Fatalf("expected cached tokens 0, got %d", usage.cachedTokens)
+	}
+}
+
+func TestParseUsageFromEventOpenAICompleted(t *testing.T) {
+	data := `{"response":{"usage":{"input_tokens":3,"output_tokens":9,"cached_tokens":2}}}`
+
+	usage, matched, err := parseUsageFromEvent(llmv1.Protocol_PROTOCOL_RESPONSES, "response.completed", data)
+	if err != nil {
+		t.Fatalf("parse event usage: %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected matched event")
+	}
+	if usage.inputTokens != 3 {
+		t.Fatalf("expected input tokens 3, got %d", usage.inputTokens)
+	}
+	if usage.outputTokens != 9 {
+		t.Fatalf("expected output tokens 9, got %d", usage.outputTokens)
+	}
+	if usage.cachedTokens != 2 {
+		t.Fatalf("expected cached tokens 2, got %d", usage.cachedTokens)
+	}
+}
+
+func TestParseUsageFromEventOpenAINonTerminal(t *testing.T) {
+	usage, matched, err := parseUsageFromEvent(llmv1.Protocol_PROTOCOL_RESPONSES, "response.created", `{"response":{}}`)
+	if err != nil {
+		t.Fatalf("parse event usage: %v", err)
+	}
+	if matched {
+		t.Fatalf("expected unmatched event")
+	}
+	if usage != (usageCounts{}) {
+		t.Fatalf("expected empty usage counts")
+	}
+}
+
+func TestParseUsageFromEventAnthropicDelta(t *testing.T) {
+	data := `{"usage":{"input_tokens":4,"output_tokens":5,"cached_tokens":1}}`
+
+	usage, matched, err := parseUsageFromEvent(llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES, "message_delta", data)
+	if err != nil {
+		t.Fatalf("parse event usage: %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected matched event")
+	}
+	if usage.inputTokens != 4 {
+		t.Fatalf("expected input tokens 4, got %d", usage.inputTokens)
+	}
+	if usage.outputTokens != 5 {
+		t.Fatalf("expected output tokens 5, got %d", usage.outputTokens)
+	}
+	if usage.cachedTokens != 1 {
+		t.Fatalf("expected cached tokens 1, got %d", usage.cachedTokens)
+	}
+}
+
+func TestParseUsageFromEventAnthropicNonTerminal(t *testing.T) {
+	usage, matched, err := parseUsageFromEvent(llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES, "message_start", `{"usage":{}}`)
+	if err != nil {
+		t.Fatalf("parse event usage: %v", err)
+	}
+	if matched {
+		t.Fatalf("expected unmatched event")
+	}
+	if usage != (usageCounts{}) {
+		t.Fatalf("expected empty usage counts")
+	}
+}
+
+func TestParseUsageFromEventUnknownProtocol(t *testing.T) {
+	usage, matched, err := parseUsageFromEvent(llmv1.Protocol_PROTOCOL_UNSPECIFIED, "response.completed", `{"response":{}}`)
+	if err != nil {
+		t.Fatalf("parse event usage: %v", err)
+	}
+	if matched {
+		t.Fatalf("expected unmatched event")
+	}
+	if usage != (usageCounts{}) {
+		t.Fatalf("expected empty usage counts")
 	}
 }


### PR DESCRIPTION
## Summary
- add metering client/config wiring for LLM proxy
- parse usage from streaming/non-streaming responses and emit metering records
- include request count records with success/failed status

## Testing
- go test ./... (fails: missing .gen packages in repo)
- golangci-lint run (fails: missing .gen packages in repo)

## Issue
- agynio/metering#1