### PR TITLE
refactor(ziticonn): drop source fallback

### DIFF
--- a/internal/ziticonn/conn.go
+++ b/internal/ziticonn/conn.go
@@ -10,10 +10,6 @@ type DialerIdentifiable interface {
 	GetDialerIdentityId() string
 }
 
-type SourceIdentifiable interface {
-	SourceIdentifier() string
-}
-
 type contextKey struct{}
 
 func WithSourceIdentity(ctx context.Context, identity string) context.Context {
@@ -32,12 +28,6 @@ func SourceIdentityFromContext(ctx context.Context) (string, bool) {
 func SourceIdentityFromConn(conn net.Conn) (string, bool) {
 	if dialer, ok := conn.(DialerIdentifiable); ok {
 		identity := strings.TrimSpace(dialer.GetDialerIdentityId())
-		if identity != "" {
-			return identity, true
-		}
-	}
-	if source, ok := conn.(SourceIdentifiable); ok {
-		identity := strings.TrimSpace(source.SourceIdentifier())
 		if identity != "" {
 			return identity, true
 		}

--- a/internal/ziticonn/conn_test.go
+++ b/internal/ziticonn/conn_test.go
@@ -29,30 +29,9 @@ type dialerConn struct {
 
 func (conn dialerConn) GetDialerIdentityId() string { return conn.dialerID }
 
-type sourceConn struct {
-	stubConn
-	sourceID string
-}
-
-func (conn sourceConn) SourceIdentifier() string { return conn.sourceID }
-
-type dialerSourceConn struct {
-	stubConn
-	dialerID string
-	sourceID string
-}
-
-func (conn dialerSourceConn) GetDialerIdentityId() string { return conn.dialerID }
-func (conn dialerSourceConn) SourceIdentifier() string { return conn.sourceID }
-
 func TestSourceIdentityFromConnDialerID(t *testing.T) {
 	conn := dialerConn{dialerID: "dialer-id"}
 	assertSourceIdentity(t, conn, "dialer-id", true)
-}
-
-func TestSourceIdentityFromConnSourceID(t *testing.T) {
-	conn := sourceConn{sourceID: "source-id"}
-	assertSourceIdentity(t, conn, "source-id", true)
 }
 
 func TestSourceIdentityFromConnMissingIdentity(t *testing.T) {
@@ -60,23 +39,8 @@ func TestSourceIdentityFromConnMissingIdentity(t *testing.T) {
 	assertSourceIdentity(t, conn, "", false)
 }
 
-func TestSourceIdentityFromConnDialerOnlyEmptyFallsThrough(t *testing.T) {
+func TestSourceIdentityFromConnDialerEmptyReturnsFalse(t *testing.T) {
 	conn := dialerConn{dialerID: ""}
-	assertSourceIdentity(t, conn, "", false)
-}
-
-func TestSourceIdentityFromConnDialerFallsBackToSource(t *testing.T) {
-	conn := dialerSourceConn{dialerID: "", sourceID: "source-id"}
-	assertSourceIdentity(t, conn, "source-id", true)
-}
-
-func TestSourceIdentityFromConnDialerPreferredOverSource(t *testing.T) {
-	conn := dialerSourceConn{dialerID: "dialer-id", sourceID: "source-id"}
-	assertSourceIdentity(t, conn, "dialer-id", true)
-}
-
-func TestSourceIdentityFromConnBothEmptyReturnsFalse(t *testing.T) {
-	conn := dialerSourceConn{dialerID: "", sourceID: ""}
 	assertSourceIdentity(t, conn, "", false)
 }
 


### PR DESCRIPTION
## Summary
- remove SourceIdentifier fallback from ziticonn source identity lookup
- streamline conn tests for dialer-only identity resolution

## Testing
- go vet ./...
- go test ./...

Fixes #40