### PR TITLE
fix(ziti): drop source fallback

### DIFF
--- a/internal/ziticonn/conn.go
+++ b/internal/ziticonn/conn.go
@@ -2,16 +2,13 @@ package ziticonn
 
 import (
 	"context"
+	"log"
 	"net"
 	"strings"
 )
 
 type DialerIdentifiable interface {
 	GetDialerIdentityId() string
-}
-
-type SourceIdentifiable interface {
-	SourceIdentifier() string
 }
 
 type contextKey struct{}
@@ -30,17 +27,17 @@ func SourceIdentityFromContext(ctx context.Context) (string, bool) {
 }
 
 func SourceIdentityFromConn(conn net.Conn) (string, bool) {
+	log.Printf("[DIAG] SourceIdentityFromConn called, conn type: %T", conn)
 	if dialer, ok := conn.(DialerIdentifiable); ok {
-		identity := strings.TrimSpace(dialer.GetDialerIdentityId())
+		id := dialer.GetDialerIdentityId()
+		log.Printf("[DIAG] GetDialerIdentityId() returned: %q", id)
+		identity := strings.TrimSpace(id)
 		if identity != "" {
 			return identity, true
 		}
+	} else {
+		log.Printf("[DIAG] conn does NOT implement DialerIdentifiable")
 	}
-	if source, ok := conn.(SourceIdentifiable); ok {
-		identity := strings.TrimSpace(source.SourceIdentifier())
-		if identity != "" {
-			return identity, true
-		}
-	}
+	log.Printf("[DIAG] no identity found, returning false")
 	return "", false
 }

--- a/internal/ziticonn/conn_test.go
+++ b/internal/ziticonn/conn_test.go
@@ -29,30 +29,9 @@ type dialerConn struct {
 
 func (conn dialerConn) GetDialerIdentityId() string { return conn.dialerID }
 
-type sourceConn struct {
-	stubConn
-	sourceID string
-}
-
-func (conn sourceConn) SourceIdentifier() string { return conn.sourceID }
-
-type dialerSourceConn struct {
-	stubConn
-	dialerID string
-	sourceID string
-}
-
-func (conn dialerSourceConn) GetDialerIdentityId() string { return conn.dialerID }
-func (conn dialerSourceConn) SourceIdentifier() string { return conn.sourceID }
-
 func TestSourceIdentityFromConnDialerID(t *testing.T) {
 	conn := dialerConn{dialerID: "dialer-id"}
 	assertSourceIdentity(t, conn, "dialer-id", true)
-}
-
-func TestSourceIdentityFromConnSourceID(t *testing.T) {
-	conn := sourceConn{sourceID: "source-id"}
-	assertSourceIdentity(t, conn, "source-id", true)
 }
 
 func TestSourceIdentityFromConnMissingIdentity(t *testing.T) {
@@ -62,21 +41,6 @@ func TestSourceIdentityFromConnMissingIdentity(t *testing.T) {
 
 func TestSourceIdentityFromConnDialerOnlyEmptyFallsThrough(t *testing.T) {
 	conn := dialerConn{dialerID: ""}
-	assertSourceIdentity(t, conn, "", false)
-}
-
-func TestSourceIdentityFromConnDialerFallsBackToSource(t *testing.T) {
-	conn := dialerSourceConn{dialerID: "", sourceID: "source-id"}
-	assertSourceIdentity(t, conn, "source-id", true)
-}
-
-func TestSourceIdentityFromConnDialerPreferredOverSource(t *testing.T) {
-	conn := dialerSourceConn{dialerID: "dialer-id", sourceID: "source-id"}
-	assertSourceIdentity(t, conn, "dialer-id", true)
-}
-
-func TestSourceIdentityFromConnBothEmptyReturnsFalse(t *testing.T) {
-	conn := dialerSourceConn{dialerID: "", sourceID: ""}
 	assertSourceIdentity(t, conn, "", false)
 }
 


### PR DESCRIPTION
## Summary
- remove SourceIdentifier fallback and add DIAG logging for dialer identities in ziti connections
- update source identity tests to match dialer-only behavior

## Testing
- go vet ./...
- go build ./...
- go test ./...

Closes #25