### PR TITLE
feat(auth): check model access

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -116,7 +116,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Printf("proxy: resolved model remote_name=%s endpoint=%s", providerConfig.remoteName, providerConfig.endpoint)
 
-	if err := h.authorizeRequest(r.Context(), resolvedIdentity, providerConfig.organizationID); err != nil {
+	if err := h.authorizeRequest(r.Context(), resolvedIdentity, modelID); err != nil {
 		writeProxyError(w, err)
 		return
 	}
@@ -219,14 +219,14 @@ func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *ht
 	h.recordMetering(meta, usage, meteringStatusSuccess)
 }
 
-func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.ResolvedIdentity, organizationID string) error {
+func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.ResolvedIdentity, modelID string) error {
 	user := fmt.Sprintf("identity:%s", resolved.IdentityID)
-	object := fmt.Sprintf("organization:%s", organizationID)
+	object := fmt.Sprintf("model:%s", modelID)
 
 	resp, err := h.authzClient.Check(ctx, &authorizationv1.CheckRequest{
 		TupleKey: &authorizationv1.TupleKey{
 			User:     user,
-			Relation: "member",
+			Relation: "can_use",
 			Object:   object,
 		},
 	})

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -142,7 +142,10 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	if authzClient.lastReq.GetTupleKey().GetUser() != "identity:user-1" {
 		t.Fatalf("unexpected authz user %q", authzClient.lastReq.GetTupleKey().GetUser())
 	}
-	if authzClient.lastReq.GetTupleKey().GetObject() != "organization:org-1" {
+	if authzClient.lastReq.GetTupleKey().GetRelation() != "can_use" {
+		t.Fatalf("unexpected authz relation %q", authzClient.lastReq.GetTupleKey().GetRelation())
+	}
+	if authzClient.lastReq.GetTupleKey().GetObject() != "model:"+modelID.String() {
 		t.Fatalf("unexpected authz object %q", authzClient.lastReq.GetTupleKey().GetObject())
 	}
 }


### PR DESCRIPTION
## Summary
- switch authorization check to model can_use relation
- keep authn/authz error mapping unchanged
- update proxy handler tests for model tuple

## Testing
- buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1
- go vet ./...
- go test ./...
- go build ./...

## Issue
- #136