### PR TITLE
Test caller header forwarding

### DIFF
--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -80,6 +80,12 @@ func TestHandlerForwardNonStream(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Fatalf("unexpected content type %q", r.Header.Get("Content-Type"))
 		}
+		if got := r.Header.Values("X-Custom-Feature"); strings.Join(got, ",") != "alpha,beta" {
+			t.Fatalf("unexpected custom feature headers %q", got)
+		}
+		if r.Header.Get("X-Trace-Id") != "trace-1" {
+			t.Fatalf("unexpected trace id header %q", r.Header.Get("X-Trace-Id"))
+		}
 		if got := r.Header.Get("Accept"); got != "" {
 			t.Fatalf("unexpected accept header %q", got)
 		}
@@ -118,6 +124,10 @@ func TestHandlerForwardNonStream(t *testing.T) {
 
 	body := `{"model":"` + modelID.String() + `","stream":false}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
+	req.Header.Add("x-custom-feature", "alpha")
+	req.Header.Add("x-custom-feature", "beta")
+	req.Header.Set("x-trace-id", "trace-1")
+	req.Header.Set("Content-Type", "text/plain")
 	ctx := identity.WithIdentity(req.Context(), identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser})
 	req = req.WithContext(ctx)
 	resp := httptest.NewRecorder()
@@ -188,6 +198,7 @@ func TestHandlerForwardStream(t *testing.T) {
 
 	body := `{"model":"` + modelID.String() + `","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
+	req.Header.Set("Accept", "application/json")
 	ctx := identity.WithIdentity(req.Context(), identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser})
 	req = req.WithContext(ctx)
 	resp := httptest.NewRecorder()
@@ -226,6 +237,12 @@ func TestHandlerForwardAnthropicMessages(t *testing.T) {
 		}
 		if r.Header.Get("Anthropic-Beta") != "prompt-caching-2024-07-31" {
 			t.Fatalf("unexpected anthropic-beta header %q", r.Header.Get("Anthropic-Beta"))
+		}
+		if got := r.Header.Values("X-Custom-Feature"); strings.Join(got, ",") != "alpha,beta" {
+			t.Fatalf("unexpected custom feature headers %q", got)
+		}
+		if r.Header.Get("X-Trace-Id") != "trace-1" {
+			t.Fatalf("unexpected trace id header %q", r.Header.Get("X-Trace-Id"))
 		}
 		assertProviderRequestHeaderAbsent(t, r.Header, "X-Agyn-Thread-Id")
 		assertProviderRequestHeaderAbsent(t, r.Header, "Connection")
@@ -277,6 +294,10 @@ func TestHandlerForwardAnthropicMessages(t *testing.T) {
 	req.Host = "caller.example"
 	req.Header.Set("anthropic-version", "2023-06-01")
 	req.Header.Set("anthropic-beta", "prompt-caching-2024-07-31")
+	req.Header.Add("x-custom-feature", "alpha")
+	req.Header.Add("x-custom-feature", "beta")
+	req.Header.Set("x-trace-id", "trace-1")
+	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Authorization", "Bearer caller-token")
 	req.Header.Set("x-api-key", "caller-key")
 	req.Header.Set("x-agyn-thread-id", "thread-1")
@@ -318,6 +339,12 @@ func TestHandlerForwardResponsesHeaders(t *testing.T) {
 		if r.Header.Get("Openai-Beta") != "responses=v1" {
 			t.Fatalf("unexpected openai-beta header %q", r.Header.Get("Openai-Beta"))
 		}
+		if r.Header.Get("X-Request-Feature") != "enabled" {
+			t.Fatalf("unexpected request feature header %q", r.Header.Get("X-Request-Feature"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("unexpected content type %q", r.Header.Get("Content-Type"))
+		}
 		assertProviderRequestHeaderAbsent(t, r.Header, "X-Api-Key")
 		assertProviderRequestHeaderAbsent(t, r.Header, "X-Agyn-Thread-Id")
 		assertProviderRequestHeaderAbsent(t, r.Header, "Connection")
@@ -350,6 +377,8 @@ func TestHandlerForwardResponsesHeaders(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
 	req.Host = "caller.example"
 	req.Header.Set("openai-beta", "responses=v1")
+	req.Header.Set("x-request-feature", "enabled")
+	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Authorization", "Bearer caller-token")
 	req.Header.Set("x-api-key", "caller-key")
 	req.Header.Set("x-agyn-thread-id", "thread-1")


### PR DESCRIPTION
## Summary
- Covers caller header forwarding for both `/v1/messages` and `/v1/responses`.
- Verifies non-allowlisted headers pass through with repeated values preserved.
- Verifies proxy-injected headers (`Content-Type`, streaming `Accept`, provider auth) override caller-supplied values while stripped header classes remain absent.

Closes #49

## Tests
- `buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 && go test ./... && go vet ./... && go build ./...`

Test stats:
- `go test ./...`: 3 packages passed, 8 packages with no test files, 0 failed, 0 skipped.
- `go vet ./...`: passed with no errors.
- `go build ./...`: passed with no errors.