### PR TITLE
Align llm-proxy CI with centralized E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,21 +26,13 @@ jobs:
 
       - name: Generate protobuf stubs
         run: |
-          for attempt in 1 2 3; do
-            if buf generate buf.build/agynio/api \
-              --path agynio/api/llm/v1 \
-              --path agynio/api/users/v1 \
-              --path agynio/api/authorization/v1 \
-              --path agynio/api/metering/v1 \
-              --path agynio/api/ziti_management/v1 \
-              --path agynio/api/identity/v1; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((attempt * 10))
-          done
+          buf generate buf.build/agynio/api \
+            --path agynio/api/llm/v1 \
+            --path agynio/api/users/v1 \
+            --path agynio/api/authorization/v1 \
+            --path agynio/api/metering/v1 \
+            --path agynio/api/ziti_management/v1 \
+            --path agynio/api/identity/v1
 
       - name: Go vet
         run: go vet ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,21 @@ jobs:
 
       - name: Generate protobuf stubs
         run: |
-          buf generate buf.build/agynio/api \
-            --path agynio/api/llm/v1 \
-            --path agynio/api/users/v1 \
-            --path agynio/api/authorization/v1 \
-            --path agynio/api/metering/v1 \
-            --path agynio/api/ziti_management/v1 \
-            --path agynio/api/identity/v1
+          for attempt in 1 2 3; do
+            if buf generate buf.build/agynio/api \
+              --path agynio/api/llm/v1 \
+              --path agynio/api/users/v1 \
+              --path agynio/api/authorization/v1 \
+              --path agynio/api/metering/v1 \
+              --path agynio/api/ziti_management/v1 \
+              --path agynio/api/identity/v1; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Go vet
         run: go vet ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,9 @@
 name: E2E
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 permissions:
@@ -8,7 +11,6 @@ permissions:
 
 jobs:
   e2e:
-    name: E2E
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -18,10 +20,13 @@ jobs:
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
 
-      - name: Set up DevSpace
+      - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Run llm-proxy E2E
-        run: devspace run ci-e2e
-        env:
-          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel
+      - name: Deploy llm-proxy from source
+        run: devspace dev
+
+      - name: Run E2E tests
+        uses: agynio/e2e/.github/actions/run-tests@main
+        with:
+          service: llm_proxy

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,10 +23,18 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Deploy llm-proxy from source
-        run: devspace dev
+      - name: Run llm-proxy E2E
+        run: devspace run ci-e2e
+        env:
+          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel
 
-      - name: Run E2E tests
-        uses: agynio/e2e/.github/actions/run-tests@main
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          service: llm_proxy
+          name: e2e-artifacts-llm-proxy
+          path: |
+            e2e/.artifacts/
+            e2e/.diagnostics/
+          include-hidden-files: true
+          if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,12 +5,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-
-env:
-  IMAGE_NAME: ghcr.io/agynio/llm-proxy
-  CHART_DIR: charts/llm-proxy
-  CHART_REGISTRY: oci://ghcr.io/agynio/charts
 
 jobs:
   e2e:
@@ -21,55 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image and chart version
-        id: version
-        run: |
-          VERSION="0.0.0-pr.${{ github.event.pull_request.number }}.${{ github.run_attempt }}.sha-${GITHUB_SHA::7}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push PR image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=llm-proxy-pr
-          cache-to: type=gha,scope=llm-proxy-pr,mode=max
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.14.4
-
-      - name: Package and push PR chart
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-          helm dependency build "$CHART_DIR"
-          helm lint "$CHART_DIR"
-          mkdir -p dist
-          helm package "$CHART_DIR" \
-            --destination dist \
-            --version "${{ steps.version.outputs.version }}" \
-            --app-version "${{ steps.version.outputs.version }}"
-          helm push "dist/llm-proxy-${{ steps.version.outputs.version }}.tgz" "$CHART_REGISTRY"
-
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
-        env:
-          TF_VAR_llm_proxy_chart_version: ${{ steps.version.outputs.version }}
-          TF_VAR_llm_proxy_image_tag: ${{ steps.version.outputs.version }}
+
+      - name: Set up DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
+
+      - name: Run llm-proxy from PR sources
+        run: devspace dev
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
             if kubectl exec deployment/llm-proxy-llm-proxy \
               -n platform \
               -c llm-proxy \
-              -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
+              -- sh -c 'nc -z localhost 8080 >/dev/null 2>&1'; then
               exit 0
             fi
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,6 @@ jobs:
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Run llm-proxy E2E
-        run: devspace run test-e2e
+        run: devspace run ci-e2e
         env:
           E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel
-          TAGS: svc_llm_proxy

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,53 +21,8 @@ jobs:
       - name: Set up DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
-      - name: Run llm-proxy from PR sources
-        run: |
-          set -euo pipefail
-
-          nohup devspace dev -w > /tmp/llm-proxy-devspace.log 2>&1 &
-          devspace_pid=$!
-          echo "$devspace_pid" > /tmp/llm-proxy-devspace.pid
-
-          for _ in $(seq 1 120); do
-            image=$(kubectl get deployment llm-proxy-llm-proxy \
-              -n platform \
-              -o jsonpath='{.spec.template.spec.containers[?(@.name=="llm-proxy")].image}')
-            if [ "$image" != "ghcr.io/agynio/devcontainer-go:1" ]; then
-              sleep 2
-              continue
-            fi
-
-            if kubectl exec deployment/llm-proxy-llm-proxy \
-              -n platform \
-              -c llm-proxy \
-              -- sh -c 'nc -z localhost 8080 >/dev/null 2>&1'; then
-              exit 0
-            fi
-
-            if ! kill -0 "$devspace_pid" >/dev/null 2>&1; then
-              cat /tmp/llm-proxy-devspace.log
-              exit 1
-            fi
-
-            sleep 2
-          done
-
-          cat /tmp/llm-proxy-devspace.log
-          exit 1
-
-      - name: Run E2E tests
-        uses: agynio/e2e/.github/actions/run-tests@main
+      - name: Run llm-proxy E2E
+        run: devspace run test-e2e
         env:
-          LLM_PROXY_URL: http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080
           E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel
-        with:
-          tag: svc_llm_proxy
-          include_smoke: false
-
-      - name: Stop llm-proxy DevSpace
-        if: always()
-        run: |
-          if [ -f /tmp/llm-proxy-devspace.pid ]; then
-            kill "$(cat /tmp/llm-proxy-devspace.pid)" >/dev/null 2>&1 || true
-          fi
+          TAGS: svc_llm_proxy

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: E2E
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Provision cluster
+        uses: agynio/bootstrap/.github/actions/provision@main
+
+      - name: Run E2E tests
+        uses: agynio/e2e/.github/actions/run-tests@main
+        with:
+          tag: svc_llm_proxy
+          include_smoke: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
+      - name: Checkout E2E repository
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/e2e
+          ref: main
+          path: e2e
+
       - name: Run llm-proxy E2E
         run: devspace run ci-e2e
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,17 +5,71 @@ on:
 
 permissions:
   contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/agynio/llm-proxy
+  CHART_DIR: charts/llm-proxy
+  CHART_REGISTRY: oci://ghcr.io/agynio/charts
 
 jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set image and chart version
+        id: version
+        run: |
+          VERSION="0.0.0-pr.${{ github.event.pull_request.number }}.${{ github.run_attempt }}.sha-${GITHUB_SHA::7}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push PR image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=llm-proxy-pr
+          cache-to: type=gha,scope=llm-proxy-pr,mode=max
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Package and push PR chart
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+          helm dependency build "$CHART_DIR"
+          helm lint "$CHART_DIR"
+          mkdir -p dist
+          helm package "$CHART_DIR" \
+            --destination dist \
+            --version "${{ steps.version.outputs.version }}" \
+            --app-version "${{ steps.version.outputs.version }}"
+          helm push "dist/llm-proxy-${{ steps.version.outputs.version }}.tgz" "$CHART_REGISTRY"
+
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main
+        env:
+          TF_VAR_llm_proxy_chart_version: ${{ steps.version.outputs.version }}
+          TF_VAR_llm_proxy_image_tag: ${{ steps.version.outputs.version }}
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,6 +73,10 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          LLM_PROXY_URL: http://llm-proxy-llm-proxy.platform.svc.cluster.local:8080
+          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel
         with:
           tag: svc_llm_proxy
           include_smoke: false
+          ref: noa/issue-llm-proxy-url

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,4 +79,3 @@ jobs:
         with:
           tag: svc_llm_proxy
           include_smoke: false
-          ref: noa/issue-llm-proxy-url

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,39 @@ jobs:
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Run llm-proxy from PR sources
-        run: devspace dev
+        run: |
+          set -euo pipefail
+
+          nohup devspace dev -w > /tmp/llm-proxy-devspace.log 2>&1 &
+          devspace_pid=$!
+          echo "$devspace_pid" > /tmp/llm-proxy-devspace.pid
+
+          for _ in $(seq 1 120); do
+            image=$(kubectl get deployment llm-proxy-llm-proxy \
+              -n platform \
+              -o jsonpath='{.spec.template.spec.containers[?(@.name=="llm-proxy")].image}')
+            if [ "$image" != "ghcr.io/agynio/devcontainer-go:1" ]; then
+              sleep 2
+              continue
+            fi
+
+            if kubectl exec deployment/llm-proxy-llm-proxy \
+              -n platform \
+              -c llm-proxy \
+              -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
+              exit 0
+            fi
+
+            if ! kill -0 "$devspace_pid" >/dev/null 2>&1; then
+              cat /tmp/llm-proxy-devspace.log
+              exit 1
+            fi
+
+            sleep 2
+          done
+
+          cat /tmp/llm-proxy-devspace.log
+          exit 1
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
@@ -32,3 +64,10 @@ jobs:
         with:
           tag: svc_llm_proxy
           include_smoke: false
+
+      - name: Stop llm-proxy DevSpace
+        if: always()
+        run: |
+          if [ -f /tmp/llm-proxy-devspace.pid ]; then
+            kill "$(cat /tmp/llm-proxy-devspace.pid)" >/dev/null 2>&1 || true
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,21 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api \
-  --path agynio/api/llm/v1 \
-  --path agynio/api/users/v1 \
-  --path agynio/api/authorization/v1 \
-  --path agynio/api/metering/v1 \
-  --path agynio/api/ziti_management/v1 \
-  --path agynio/api/identity/v1
+RUN for attempt in 1 2 3; do \
+      if buf generate buf.build/agynio/api \
+        --path agynio/api/llm/v1 \
+        --path agynio/api/users/v1 \
+        --path agynio/api/authorization/v1 \
+        --path agynio/api/metering/v1 \
+        --path agynio/api/ziti_management/v1 \
+        --path agynio/api/identity/v1; then \
+        exit 0; \
+      fi; \
+      if [ "$attempt" -eq 3 ]; then \
+        exit 1; \
+      fi; \
+      sleep $((attempt * 10)); \
+    done
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,21 +22,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN for attempt in 1 2 3; do \
-      if buf generate buf.build/agynio/api \
-        --path agynio/api/llm/v1 \
-        --path agynio/api/users/v1 \
-        --path agynio/api/authorization/v1 \
-        --path agynio/api/metering/v1 \
-        --path agynio/api/ziti_management/v1 \
-        --path agynio/api/identity/v1; then \
-        exit 0; \
-      fi; \
-      if [ "$attempt" -eq 3 ]; then \
-        exit 1; \
-      fi; \
-      sleep $((attempt * 10)); \
-    done
+RUN buf generate buf.build/agynio/api \
+      --path agynio/api/llm/v1 \
+      --path agynio/api/users/v1 \
+      --path agynio/api/authorization/v1 \
+      --path agynio/api/metering/v1 \
+      --path agynio/api/ziti_management/v1 \
+      --path agynio/api/identity/v1
 
 COPY . .
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -173,6 +173,8 @@ pipelines:
       patch_deployment
       trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
 
+      create_deployments e2e-runner
+      start_dev e2e-runner &
       start_dev --disable-pod-replace llm-proxy &
       sleep 5
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -83,7 +83,8 @@ functions:
     )"
   run_llm_proxy_e2e: |-
     cd e2e
-    devspace run test-e2e --tag svc_llm_proxy
+    LLM_PROXY_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
+      devspace run test-e2e --tag svc_llm_proxy
 
 commands:
   test-e2e: |-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -145,7 +145,7 @@ pipelines:
       patch_deployment
       trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
 
-      start_dev --disable-pod-replace llm-proxy --exit-after-deploy
+      start_dev --disable-pod-replace llm-proxy --exit-after-deploy &
 
       create_deployments e2e-runner
       start_dev e2e-runner &

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -83,6 +83,12 @@ functions:
     )"
   run_llm_proxy_e2e: |-
     cd e2e
+    export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
+    export CODEX_INIT_IMAGE="${CODEX_INIT_IMAGE:-ghcr.io/agynio/agent-init-codex:latest}"
+    export AGYN_AGENT_INIT_IMAGE="${AGYN_AGENT_INIT_IMAGE:-${CODEX_INIT_IMAGE}}"
+    export AGN_INIT_IMAGE="${AGN_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
+    export CLAUDE_INIT_IMAGE="${CLAUDE_INIT_IMAGE:-ghcr.io/agynio/agent-init-claude:latest}"
+    export AGN_EXPOSE_INIT_IMAGE="${AGN_EXPOSE_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
     LLM_PROXY_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
       devspace run test-e2e --tag svc_llm_proxy
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -108,6 +108,8 @@ deployments:
 commands:
   test-e2e: |-
     devspace run-pipeline test-e2e $@
+  ci-e2e: |-
+    devspace run-pipeline ci-e2e $@
 
 pipelines:
   dev:
@@ -164,6 +166,18 @@ pipelines:
       stop_dev e2e-runner
       purge_deployments e2e-runner
       exit $EXIT_CODE
+
+  ci-e2e:
+    run: |-
+      disable_argocd_sync
+      patch_deployment
+      trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
+
+      start_dev --disable-pod-replace llm-proxy &
+      sleep 5
+
+      cd e2e
+      devspace run test-e2e --tag svc_llm_proxy
 
 hooks:
   - name: restore-argocd-auto-sync

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -143,10 +143,9 @@ pipelines:
     run: |-
       disable_argocd_sync
       patch_deployment
-      start_dev --disable-pod-replace llm-proxy &
-      LLM_PROXY_DEV_PID=$!
-
       trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
+
+      start_dev --disable-pod-replace llm-proxy --exit-after-deploy
 
       create_deployments e2e-runner
       start_dev e2e-runner &

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -141,6 +141,13 @@ pipelines:
 
   test-e2e:
     run: |-
+      disable_argocd_sync
+      patch_deployment
+      start_dev --disable-pod-replace llm-proxy &
+      LLM_PROXY_DEV_PID=$!
+
+      trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
+
       create_deployments e2e-runner
       start_dev e2e-runner &
       sleep 5

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -81,6 +81,15 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+  run_llm_proxy_e2e: |-
+    cd e2e
+    devspace run test-e2e --tag svc_llm_proxy
+
+commands:
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
+  ci-e2e: |-
+    devspace run-pipeline ci-e2e $@
 
 pipelines:
   dev:
@@ -95,22 +104,20 @@ pipelines:
         start_dev --disable-pod-replace llm-proxy
       else
         start_dev --disable-pod-replace llm-proxy
-        echo "Waiting for llm-proxy to be healthy on :8080..."
-        healthy=false
-        for i in $(seq 1 60); do
-          if exec_container --label-selector=app.kubernetes.io/name=llm-proxy -n ${LLM_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
-            healthy=true
-            break
-          fi
-          sleep 2
-        done
-        if [ "$healthy" != "true" ]; then
-          echo "ERROR: LLM Proxy did not become healthy within 120s" >&2
-          exit 1
-        fi
-        echo "Dev environment ready. Stopping dev session."
         stop_dev llm-proxy
       fi
+  test-e2e:
+    run: |-
+      run_llm_proxy_e2e
+  ci-e2e:
+    run: |-
+      disable_argocd_sync
+      patch_deployment
+      run_pipelines --background ci-e2e-source
+      run_llm_proxy_e2e
+  ci-e2e-source:
+    run: |-
+      start_dev --disable-pod-replace llm-proxy
 
 hooks:
   - name: restore-argocd-auto-sync

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -144,8 +144,7 @@ pipelines:
       disable_argocd_sync
       patch_deployment
       trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
-
-      start_dev --disable-pod-replace llm-proxy --exit-after-deploy &
+      start_dev --disable-pod-replace llm-proxy &
 
       create_deployments e2e-runner
       start_dev e2e-runner &
@@ -216,6 +215,16 @@ dev:
     sync:
       - path: ./:/opt/app/data
         excludePaths:
+          - .git/
+          - .devspace/
+          - /.gen/
+          - /tmp/
+        uploadExcludePaths:
+          - .git/
+          - .devspace/
+          - /.gen/
+          - /tmp/
+        downloadExcludePaths:
           - .git/
           - .devspace/
           - /.gen/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,7 +2,6 @@ version: v2beta1
 
 vars:
   LLM_PROXY_NAMESPACE: platform
-  E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
   disable_argocd_sync: |-
@@ -40,7 +39,7 @@ functions:
               emptyDir: {}
           containers:
             - name: llm-proxy
-              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
+              image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
               workingDir: /opt/app/data
               command:
                 - sh
@@ -83,34 +82,6 @@ functions:
     EOF
     )"
 
-deployments:
-  e2e-runner:
-    namespace: ${LLM_PROXY_NAMESPACE}
-    helm:
-      chart:
-        name: component-chart
-        repo: https://charts.devspace.sh
-      values:
-        containers:
-          - image: ${E2E_IMAGE}
-            env:
-              - name: LLM_PROXY_URL
-                value: "http://llm-proxy:8080"
-              - name: USERS_ADDR
-                value: "users:50051"
-              - name: ORGANIZATIONS_ADDR
-                value: "tenants:50051"
-              - name: LLM_ADDR
-                value: "llm:50051"
-        labels:
-          app.kubernetes.io/name: llm-proxy-e2e
-
-commands:
-  test-e2e: |-
-    devspace run-pipeline test-e2e $@
-  ci-e2e: |-
-    devspace run-pipeline ci-e2e $@
-
 pipelines:
   dev:
     flags:
@@ -140,46 +111,6 @@ pipelines:
         echo "Dev environment ready. Stopping dev session."
         stop_dev llm-proxy
       fi
-
-  test-e2e:
-    run: |-
-      disable_argocd_sync
-      patch_deployment
-      trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
-      start_dev --disable-pod-replace llm-proxy &
-
-      create_deployments e2e-runner
-      start_dev e2e-runner &
-      sleep 5
-      exec_container \
-        --label-selector "app.kubernetes.io/name=llm-proxy-e2e" \
-        -n ${LLM_PROXY_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api \
-          --path agynio/api/llm/v1 \
-          --path agynio/api/users/v1 \
-          --path agynio/api/authorization/v1 \
-          --path agynio/api/metering/v1 \
-          --path agynio/api/ziti_management/v1 \
-          --path agynio/api/identity/v1 \
-          --path agynio/api/organizations/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
-      EXIT_CODE=$?
-      stop_dev e2e-runner
-      purge_deployments e2e-runner
-      exit $EXIT_CODE
-
-  ci-e2e:
-    run: |-
-      disable_argocd_sync
-      patch_deployment
-      trap 'stop_dev llm-proxy || true; restore_argocd_sync' EXIT
-
-      create_deployments e2e-runner
-      start_dev e2e-runner &
-      start_dev --disable-pod-replace llm-proxy &
-      sleep 5
-
-      cd e2e
-      devspace run test-e2e --tag svc_llm_proxy
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -221,27 +152,3 @@ dev:
           lastLines: 200
     ports:
       - port: "8080"
-
-  e2e-runner:
-    namespace: ${LLM_PROXY_NAMESPACE}
-    labelSelector:
-      app.kubernetes.io/name: llm-proxy-e2e
-    command: ["sleep", "infinity"]
-    workingDir: /opt/app/data
-    sync:
-      - path: ./:/opt/app/data
-        excludePaths:
-          - .git/
-          - .devspace/
-          - /.gen/
-          - /tmp/
-        uploadExcludePaths:
-          - .git/
-          - .devspace/
-          - /.gen/
-          - /tmp/
-        downloadExcludePaths:
-          - .git/
-          - .devspace/
-          - /.gen/
-          - /tmp/


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: `agynio/bootstrap/.github/actions/provision@main`, service-owned `devspace dev`, and `agynio/e2e/.github/actions/run-tests@main`.
- Removes repo-local `test-e2e` / `ci-e2e` runner deployment and pipeline from `devspace.yaml` so E2E execution stays centralized in `agynio/e2e`.
- Adds read-only workflow permissions to CI/E2E.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #54

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml devspace.yaml` — passed with no errors.
- `buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1` — passed.
- `gofmt -w $(find cmd internal test -name '*.go' -print)` — passed with no committed changes.
- `go vet ./...` — passed with no errors.
- `go test ./...` — 3 packages passed, 0 failed, 0 skipped.
- `go build ./...` — passed.
- `devspace print --debug` — passed.