### PR TITLE
fix: gate llm-proxy e2e on source readiness

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -196,6 +196,7 @@ dev:
             value: "false"
         sync:
           - path: ./:/opt/app/data
+            initialSync: preferLocal
             disableDownload: true
             excludePaths:
               - .git/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -54,14 +54,6 @@ functions:
                 limits:
                   cpu: "2"
                   memory: 4Gi
-              startupProbe:
-                exec:
-                  command:
-                    - test
-                    - -f
-                    - /tmp/llm-proxy-source-ready
-                periodSeconds: 2
-                failureThreshold: 180
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -28,6 +28,7 @@ functions:
     echo "Patching llm-proxy deployment for DevSpace..."
     kubectl patch deployment llm-proxy-llm-proxy -n ${LLM_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
+      replicas: 1
       template:
         spec:
           securityContext:
@@ -54,6 +55,17 @@ functions:
                 limits:
                   cpu: "2"
                   memory: 4Gi
+              livenessProbe:
+                tcpSocket: null
+                httpGet: null
+                exec:
+                  command: ["true"]
+              readinessProbe:
+                tcpSocket: null
+                httpGet: null
+                exec:
+                  command: ["true"]
+              startupProbe: null
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000
@@ -66,13 +78,14 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+    kubectl set env deployment/llm-proxy-llm-proxy -n ${LLM_PROXY_NAMESPACE} ZITI_ENABLED=false
   wait_for_source_deployment: |-
     exec_container \
       --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
       --container=llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
       --timeout=600 \
-      -- sh -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git'
+      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git && (nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1)'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
@@ -135,7 +148,7 @@ dev:
       llm-proxy:
         container: llm-proxy
         command:
-          - sh
+          - bash
           - -c
           - |-
             set -eu

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -99,21 +99,32 @@ functions:
     EOF
     )"
   wait_for_source_deployment: |-
-    kubectl wait pod \
+    pod_name="$(kubectl get pod \
       -n ${LLM_PROXY_NAMESPACE} \
       --selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy,agyn.io/source-run=true \
+      --sort-by=.metadata.creationTimestamp \
+      -o jsonpath='{.items[-1:].metadata.name}')"
+    test -n "${pod_name}"
+    kubectl wait pod \
+      -n ${LLM_PROXY_NAMESPACE} \
+      "${pod_name}" \
       --for=condition=Ready \
       --timeout=600s
     kubectl exec \
       -n ${LLM_PROXY_NAMESPACE} \
-      deploy/llm-proxy-llm-proxy \
+      "${pod_name}" \
       -c llm-proxy \
-      -- bash -c 'set -eu; cd /opt/app/data; buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1; go build -o /tmp/llm-proxy ./cmd/llm-proxy; echo ready > /tmp/llm-proxy-source-ready; nohup /tmp/llm-proxy >/tmp/llm-proxy.log 2>&1 &'
+      -- bash -c 'set -eu; cd /opt/app/data; buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1; go build -o /tmp/llm-proxy ./cmd/llm-proxy; echo ready > /tmp/llm-proxy-source-ready'
     kubectl exec \
       -n ${LLM_PROXY_NAMESPACE} \
-      deploy/llm-proxy-llm-proxy \
+      "${pod_name}" \
       -c llm-proxy \
-      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 || { cat /tmp/llm-proxy.log >&2; echo "llm-proxy source deployment is not ready" >&2; exit 1; }'
+      -- bash -c 'rm -f /tmp/llm-proxy.log; nohup /tmp/llm-proxy >/tmp/llm-proxy.log 2>&1 &'
+    kubectl exec \
+      -n ${LLM_PROXY_NAMESPACE} \
+      "${pod_name}" \
+      -c llm-proxy \
+      -- bash -c 'set -eu; test -f /tmp/llm-proxy-source-ready; test -f /opt/app/data/go.mod; test "$(cat /proc/1/comm)" = sleep; pgrep -f /tmp/llm-proxy >/dev/null; (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 || { cat /tmp/llm-proxy.log >&2; echo "llm-proxy source deployment is not ready" >&2; exit 1; }'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -41,28 +41,9 @@ functions:
             - name: llm-proxy
               image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
               workingDir: /opt/app/data
-              env:
-                - name: ZITI_ENABLED
-                  value: "false"
               command:
-                - sh
-                - -c
-                - |
-                  set -eu
-                  elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-                  done
-                  buf generate buf.build/agynio/api \
-                    --path agynio/api/llm/v1 \
-                    --path agynio/api/users/v1 \
-                    --path agynio/api/authorization/v1 \
-                    --path agynio/api/metering/v1 \
-                    --path agynio/api/ziti_management/v1 \
-                    --path agynio/api/identity/v1
-                  echo ready > /tmp/llm-proxy-source-ready
-                  exec go run ./cmd/llm-proxy
+                - sleep
+                - infinity
               volumeMounts:
                 - name: data
                   mountPath: /opt/app/data
@@ -74,8 +55,11 @@ functions:
                   cpu: "2"
                   memory: 4Gi
               startupProbe:
-                tcpSocket:
-                  port: http
+                exec:
+                  command:
+                    - test
+                    - -f
+                    - /tmp/llm-proxy-source-ready
                 periodSeconds: 2
                 failureThreshold: 180
               securityContext:
@@ -91,16 +75,11 @@ functions:
     EOF
     )"
   wait_for_source_deployment: |-
-    wait_pod \
-      --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
-      --container=llm-proxy \
-      -n ${LLM_PROXY_NAMESPACE} \
-      --timeout=180
     exec_container \
       --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
       --container=llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
-      --timeout=180 \
+      --timeout=600 \
       -- sh -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git'
   run_llm_proxy_e2e: |-
     cd e2e
@@ -163,8 +142,26 @@ dev:
     containers:
       llm-proxy:
         container: llm-proxy
+        command:
+          - sh
+          - -c
+          - |-
+            set -eu
+            buf generate buf.build/agynio/api \
+              --path agynio/api/llm/v1 \
+              --path agynio/api/users/v1 \
+              --path agynio/api/authorization/v1 \
+              --path agynio/api/metering/v1 \
+              --path agynio/api/ziti_management/v1 \
+              --path agynio/api/identity/v1
+            echo ready > /tmp/llm-proxy-source-ready
+            exec go run ./cmd/llm-proxy
+        env:
+          - name: ZITI_ENABLED
+            value: "false"
         sync:
           - path: ./:/opt/app/data
+            startContainer: true
             excludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -205,17 +205,17 @@ dev:
             excludePaths:
               - .git/
               - .devspace/
-              - /.gen/
+              - .gen/
               - /tmp/
             uploadExcludePaths:
               - .git/
               - .devspace/
-              - /.gen/
+              - .gen/
               - /tmp/
             downloadExcludePaths:
               - .git/
               - .devspace/
-              - /.gen/
+              - .gen/
               - /tmp/
         logs:
           enabled: true

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -59,6 +59,10 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 180 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
+                  elapsed=0
+                  while [ "$elapsed" -lt 5 ]; do
+                    sleep 1; elapsed=$((elapsed + 1))
+                  done
                   buf generate buf.build/agynio/api \
                     --path agynio/api/llm/v1 \
                     --path agynio/api/users/v1 \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -130,11 +130,19 @@ functions:
     EOF
     )"
   wait_for_source_deployment: |-
-    exec_container \
-      --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy,agyn.io/source-run=true \
-      --container=llm-proxy \
+    kubectl wait deployment/llm-proxy-llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
-      --timeout=600 \
+      --for=condition=Available \
+      --timeout=600s
+    kubectl wait pod \
+      -n ${LLM_PROXY_NAMESPACE} \
+      --selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy,agyn.io/source-run=true \
+      --for=condition=Ready \
+      --timeout=600s
+    kubectl exec \
+      -n ${LLM_PROXY_NAMESPACE} \
+      deploy/llm-proxy-llm-proxy \
+      -c llm-proxy \
       -- bash -c 'elapsed=0; while [ "$elapsed" -lt 120 ]; do test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 && exit 0; sleep 1; elapsed=$((elapsed + 1)); done; echo "llm-proxy source deployment is not ready" >&2; exit 1'
   run_llm_proxy_e2e: |-
     cd e2e

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -116,15 +116,6 @@ functions:
     EOF
     )"
   wait_for_source_deployment: |-
-    kubectl wait deployment/llm-proxy-llm-proxy \
-      -n ${LLM_PROXY_NAMESPACE} \
-      --for=condition=Available \
-      --timeout=600s
-    kubectl wait pod \
-      -n ${LLM_PROXY_NAMESPACE} \
-      --selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy,agyn.io/source-run=true \
-      --for=condition=Ready \
-      --timeout=600s
     kubectl exec \
       -n ${LLM_PROXY_NAMESPACE} \
       deploy/llm-proxy-llm-proxy \
@@ -192,6 +183,9 @@ dev:
     containers:
       llm-proxy:
         container: llm-proxy
+        command:
+          - sleep
+          - infinity
         env:
           - name: ZITI_ENABLED
             value: "false"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -45,8 +45,24 @@ functions:
               image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
               workingDir: /opt/app/data
               command:
-                - sleep
-                - infinity
+                - bash
+                - -c
+                - |
+                  set -eu
+                  elapsed=0
+                  while [ ! -f /opt/app/data/go.mod ]; do
+                    sleep 1; elapsed=$((elapsed + 1))
+                    [ "$elapsed" -ge 180 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                  done
+                  buf generate buf.build/agynio/api \
+                    --path agynio/api/llm/v1 \
+                    --path agynio/api/users/v1 \
+                    --path agynio/api/authorization/v1 \
+                    --path agynio/api/metering/v1 \
+                    --path agynio/api/ziti_management/v1 \
+                    --path agynio/api/identity/v1
+                  echo ready > /tmp/llm-proxy-source-ready
+                  exec go run ./cmd/llm-proxy
               volumeMounts:
                 - name: devspace-start
                   mountPath: /.devspace
@@ -89,7 +105,7 @@ functions:
       --container=llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
       --timeout=600 \
-      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git && (nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1) || { echo "llm-proxy source deployment is not ready" >&2; exit 1; }'
+      -- bash -c 'for i in $(seq 1 120); do test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git && (nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1) && exit 0; sleep 1; done; echo "llm-proxy source deployment is not ready" >&2; exit 1'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
@@ -151,26 +167,11 @@ dev:
     containers:
       llm-proxy:
         container: llm-proxy
-        command:
-          - bash
-          - -c
-          - |-
-            set -eu
-            buf generate buf.build/agynio/api \
-              --path agynio/api/llm/v1 \
-              --path agynio/api/users/v1 \
-              --path agynio/api/authorization/v1 \
-              --path agynio/api/metering/v1 \
-              --path agynio/api/ziti_management/v1 \
-              --path agynio/api/identity/v1
-            echo ready > /tmp/llm-proxy-source-ready
-            exec go run ./cmd/llm-proxy
         env:
           - name: ZITI_ENABLED
             value: "false"
         sync:
           - path: ./:/opt/app/data
-            startContainer: true
             excludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -36,6 +36,8 @@ functions:
             fsGroup: 1000
           initContainers: []
           volumes:
+            - name: devspace-start
+              emptyDir: {}
             - name: data
               emptyDir: {}
           containers:
@@ -46,6 +48,8 @@ functions:
                 - sleep
                 - infinity
               volumeMounts:
+                - name: devspace-start
+                  mountPath: /.devspace
                 - name: data
                   mountPath: /opt/app/data
               resources:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -116,6 +116,11 @@ functions:
     EOF
     )"
   wait_for_source_deployment: |-
+    kubectl wait pod \
+      -n ${LLM_PROXY_NAMESPACE} \
+      --selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy,agyn.io/source-run=true \
+      --for=condition=Ready \
+      --timeout=600s
     kubectl exec \
       -n ${LLM_PROXY_NAMESPACE} \
       deploy/llm-proxy-llm-proxy \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -50,29 +50,8 @@ functions:
               image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
               workingDir: /opt/app/data
               command:
-                - bash
-                - -c
-                - |
-                  set -eu
-                  elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 180 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-                  done
-                  elapsed=0
-                  while [ "$elapsed" -lt 5 ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                  done
-                  buf generate buf.build/agynio/api \
-                    --path agynio/api/llm/v1 \
-                    --path agynio/api/users/v1 \
-                    --path agynio/api/authorization/v1 \
-                    --path agynio/api/metering/v1 \
-                    --path agynio/api/ziti_management/v1 \
-                    --path agynio/api/identity/v1
-                  go build -o /tmp/llm-proxy ./cmd/llm-proxy
-                  echo ready > /tmp/llm-proxy-source-ready
-                  exec /tmp/llm-proxy
+                - sleep
+                - infinity
               volumeMounts:
                 - name: devspace-start
                   mountPath: /.devspace
@@ -129,7 +108,12 @@ functions:
       -n ${LLM_PROXY_NAMESPACE} \
       deploy/llm-proxy-llm-proxy \
       -c llm-proxy \
-      -- bash -c 'elapsed=0; while [ "$elapsed" -lt 120 ]; do test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 && exit 0; sleep 1; elapsed=$((elapsed + 1)); done; echo "llm-proxy source deployment is not ready" >&2; exit 1'
+      -- bash -c 'set -eu; cd /opt/app/data; buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1; go build -o /tmp/llm-proxy ./cmd/llm-proxy; echo ready > /tmp/llm-proxy-source-ready; nohup /tmp/llm-proxy >/tmp/llm-proxy.log 2>&1 &'
+    kubectl exec \
+      -n ${LLM_PROXY_NAMESPACE} \
+      deploy/llm-proxy-llm-proxy \
+      -c llm-proxy \
+      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 || { cat /tmp/llm-proxy.log >&2; echo "llm-proxy source deployment is not ready" >&2; exit 1; }'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -70,6 +70,11 @@ functions:
                 limits:
                   cpu: "2"
                   memory: 4Gi
+              startupProbe:
+                tcpSocket:
+                  port: http
+                periodSeconds: 2
+                failureThreshold: 180
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -41,6 +41,9 @@ functions:
             - name: llm-proxy
               image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
               workingDir: /opt/app/data
+              env:
+                - name: ZITI_ENABLED
+                  value: "false"
               command:
                 - sh
                 - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -66,23 +66,9 @@ functions:
                     --path agynio/api/metering/v1 \
                     --path agynio/api/ziti_management/v1 \
                     --path agynio/api/identity/v1
-                  go run ./cmd/llm-proxy &
-                  server_pid="$!"
-                  trap 'kill "${server_pid}" 2>/dev/null || true' INT TERM
-                  elapsed=0
-                  while [ "$elapsed" -lt 120 ]; do
-                    if ! kill -0 "${server_pid}" 2>/dev/null; then
-                      wait "${server_pid}"
-                    fi
-                    if (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1; then
-                      echo ready > /tmp/llm-proxy-source-ready
-                      wait "${server_pid}"
-                    fi
-                    sleep 1; elapsed=$((elapsed + 1))
-                  done
-                  echo "ERROR: llm-proxy source server did not become ready" >&2
-                  kill "${server_pid}" 2>/dev/null || true
-                  wait "${server_pid}"
+                  go build -o /tmp/llm-proxy ./cmd/llm-proxy
+                  echo ready > /tmp/llm-proxy-source-ready
+                  exec /tmp/llm-proxy
               volumeMounts:
                 - name: devspace-start
                   mountPath: /.devspace

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -89,7 +89,7 @@ functions:
       --container=llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
       --timeout=600 \
-      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git && (nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1)'
+      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git && (nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1) || { echo "llm-proxy source deployment is not ready" >&2; exit 1; }'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -109,7 +109,7 @@ functions:
       --container=llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
       --timeout=600 \
-      -- bash -c 'for i in $(seq 1 120); do test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git && (nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1) && exit 0; sleep 1; done; echo "llm-proxy source deployment is not ready" >&2; exit 1'
+      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git || { echo "llm-proxy source marker is not ready" >&2; exit 1; }'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -30,6 +30,9 @@ functions:
     spec:
       replicas: 1
       template:
+        metadata:
+          labels:
+            agyn.io/source-run: "true"
         spec:
           securityContext:
             runAsUser: 1000
@@ -63,8 +66,23 @@ functions:
                     --path agynio/api/metering/v1 \
                     --path agynio/api/ziti_management/v1 \
                     --path agynio/api/identity/v1
-                  echo ready > /tmp/llm-proxy-source-ready
-                  exec go run ./cmd/llm-proxy
+                  go run ./cmd/llm-proxy &
+                  server_pid="$!"
+                  trap 'kill "${server_pid}" 2>/dev/null || true' INT TERM
+                  elapsed=0
+                  while [ "$elapsed" -lt 120 ]; do
+                    if ! kill -0 "${server_pid}" 2>/dev/null; then
+                      wait "${server_pid}"
+                    fi
+                    if (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1; then
+                      echo ready > /tmp/llm-proxy-source-ready
+                      wait "${server_pid}"
+                    fi
+                    sleep 1; elapsed=$((elapsed + 1))
+                  done
+                  echo "ERROR: llm-proxy source server did not become ready" >&2
+                  kill "${server_pid}" 2>/dev/null || true
+                  wait "${server_pid}"
               volumeMounts:
                 - name: devspace-start
                   mountPath: /.devspace
@@ -103,13 +121,21 @@ functions:
     EOF
     )"
     kubectl set env deployment/llm-proxy-llm-proxy -n ${LLM_PROXY_NAMESPACE} ZITI_ENABLED=false
+    kubectl patch service llm-proxy-llm-proxy -n ${LLM_PROXY_NAMESPACE} --type merge --patch "$(cat <<'EOF'
+    spec:
+      selector:
+        app.kubernetes.io/name: llm-proxy
+        app.kubernetes.io/instance: llm-proxy
+        agyn.io/source-run: "true"
+    EOF
+    )"
   wait_for_source_deployment: |-
     exec_container \
-      --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
+      --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy,agyn.io/source-run=true \
       --container=llm-proxy \
       -n ${LLM_PROXY_NAMESPACE} \
       --timeout=600 \
-      -- bash -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git || { echo "llm-proxy source marker is not ready" >&2; exit 1; }'
+      -- bash -c 'elapsed=0; while [ "$elapsed" -lt 120 ]; do test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && (echo > /dev/tcp/127.0.0.1/8080) >/dev/null 2>&1 && exit 0; sleep 1; elapsed=$((elapsed + 1)); done; echo "llm-proxy source deployment is not ready" >&2; exit 1'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
@@ -168,6 +194,7 @@ dev:
     labelSelector:
       app.kubernetes.io/name: llm-proxy
       app.kubernetes.io/instance: llm-proxy
+      agyn.io/source-run: "true"
     containers:
       llm-proxy:
         container: llm-proxy

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -40,6 +40,8 @@ functions:
               emptyDir: {}
             - name: data
               emptyDir: {}
+            - name: tmp
+              emptyDir: {}
           containers:
             - name: llm-proxy
               image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
@@ -68,6 +70,8 @@ functions:
                   mountPath: /.devspace
                 - name: data
                   mountPath: /opt/app/data
+                - name: tmp
+                  mountPath: /tmp
               resources:
                 requests:
                   cpu: 500m

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -196,6 +196,7 @@ dev:
             value: "false"
         sync:
           - path: ./:/opt/app/data
+            disableDownload: true
             excludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -58,6 +58,7 @@ functions:
                     --path agynio/api/metering/v1 \
                     --path agynio/api/ziti_management/v1 \
                     --path agynio/api/identity/v1
+                  echo ready > /tmp/llm-proxy-source-ready
                   exec go run ./cmd/llm-proxy
               volumeMounts:
                 - name: data
@@ -81,6 +82,18 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+  wait_for_source_deployment: |-
+    wait_pod \
+      --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
+      --container=llm-proxy \
+      -n ${LLM_PROXY_NAMESPACE} \
+      --timeout=180
+    exec_container \
+      --label-selector=app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
+      --container=llm-proxy \
+      -n ${LLM_PROXY_NAMESPACE} \
+      --timeout=180 \
+      -- sh -c 'test -f /tmp/llm-proxy-source-ready && test -f /opt/app/data/go.mod && test -d /opt/app/data/.git'
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
@@ -120,11 +133,9 @@ pipelines:
     run: |-
       disable_argocd_sync
       patch_deployment
-      run_pipelines --background ci-e2e-source
-      run_llm_proxy_e2e
-  ci-e2e-source:
-    run: |-
       start_dev --disable-pod-replace llm-proxy
+      wait_for_source_deployment
+      run_llm_proxy_e2e
 
 hooks:
   - name: restore-argocd-auto-sync


### PR DESCRIPTION
## Summary
- Make `ci-e2e` start the PR source DevSpace deployment synchronously instead of through an unawaited background pipeline.
- Add a DevSpace readiness gate that fails before shared E2E unless the patched pod has synced PR sources and reached the source command after `buf generate`.
- Keep shared `svc_llm_proxy` E2E running through the single `devspace run ci-e2e` workflow command.

Fixes follow-up from #55 / #54.

## Test & Lint Summary
Pending final CI confirmation.