### PR TITLE
ci: run agent thread e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,10 +10,6 @@ permissions:
   contents: read
   packages: read
 
-env:
-  K3D_IMAGE_TOOLS: ghcr.io/k3d-io/k3d-tools:5.7.5
-  K3D_IMAGE_LOADBALANCER: ghcr.io/k3d-io/k3d-proxy:5.7.5
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -21,28 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Pre-pull k3d helper images
-        run: |
-          set -euo pipefail
-          for image in "${K3D_IMAGE_TOOLS}" "${K3D_IMAGE_LOADBALANCER}"; do
-            for attempt in 1 2 3 4 5; do
-              if docker pull "${image}"; then
-                break
-              fi
-              sleep_seconds=$((attempt * 10))
-              echo "docker pull ${image} failed on attempt ${attempt}; retrying in ${sleep_seconds}s" >&2
-              sleep "${sleep_seconds}"
-            done
-            docker image inspect "${image}" >/dev/null
-          done
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,10 @@ on:
 
 permissions:
   contents: read
+  packages: read
+
+env:
+  K3D_IMAGE_TOOLS: ghcr.io/k3d-io/k3d-tools:5.7.5
 
 jobs:
   e2e:
@@ -16,6 +20,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Pre-pull k3d tools image
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if docker pull "${K3D_IMAGE_TOOLS}"; then
+              exit 0
+            fi
+            sleep_seconds=$((attempt * 10))
+            echo "docker pull ${K3D_IMAGE_TOOLS} failed on attempt ${attempt}; retrying in ${sleep_seconds}s" >&2
+            sleep "${sleep_seconds}"
+          done
+          docker pull "${K3D_IMAGE_TOOLS}"
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/e2e
-          ref: noa/issue-57
+          ref: main
           path: e2e
 
       - name: Run llm-proxy E2E
@@ -62,7 +62,7 @@ jobs:
         env:
           E2E_SUITES: go-core
           E2E_TAGS: svc_agents_orchestrator svc_llm_proxy
-          E2E_GO_TEST_RUN: TestAgentRespondsToThreadMessageViaLLMProxy
+          E2E_GO_TEST_RUN: "^(TestLLMProxyGatewayCreatedModel|TestFullPipelineAgnMessageResponse)$"
 
       - name: Upload E2E artifacts
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   K3D_IMAGE_TOOLS: ghcr.io/k3d-io/k3d-tools:5.7.5
+  K3D_IMAGE_LOADBALANCER: ghcr.io/k3d-io/k3d-proxy:5.7.5
 
 jobs:
   e2e:
@@ -28,18 +29,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Pre-pull k3d tools image
+      - name: Pre-pull k3d helper images
         run: |
           set -euo pipefail
-          for attempt in 1 2 3 4 5; do
-            if docker pull "${K3D_IMAGE_TOOLS}"; then
-              exit 0
-            fi
-            sleep_seconds=$((attempt * 10))
-            echo "docker pull ${K3D_IMAGE_TOOLS} failed on attempt ${attempt}; retrying in ${sleep_seconds}s" >&2
-            sleep "${sleep_seconds}"
+          for image in "${K3D_IMAGE_TOOLS}" "${K3D_IMAGE_LOADBALANCER}"; do
+            for attempt in 1 2 3 4 5; do
+              if docker pull "${image}"; then
+                break
+              fi
+              sleep_seconds=$((attempt * 10))
+              echo "docker pull ${image} failed on attempt ${attempt}; retrying in ${sleep_seconds}s" >&2
+              sleep "${sleep_seconds}"
+            done
+            docker image inspect "${image}" >/dev/null
           done
-          docker pull "${K3D_IMAGE_TOOLS}"
 
       - name: Provision cluster
         uses: agynio/bootstrap/.github/actions/provision@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Run llm-proxy E2E
         run: devspace run ci-e2e
         env:
-          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel
+          E2E_TAGS: svc_agents_orchestrator svc_llm_proxy
+          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel|TestAgentRespondsToThreadMessageViaLLMProxy
 
       - name: Upload E2E artifacts
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,14 +51,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/e2e
-          ref: main
+          ref: noa/issue-57
           path: e2e
 
       - name: Run llm-proxy E2E
         run: devspace run ci-e2e
         env:
+          E2E_SUITES: go-core
           E2E_TAGS: svc_agents_orchestrator svc_llm_proxy
-          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel|TestFullPipelineAgnMessageResponse
+          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel|TestAgentRespondsToThreadMessageViaLLMProxy
 
       - name: Upload E2E artifacts
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
         run: devspace run ci-e2e
         env:
           E2E_TAGS: svc_agents_orchestrator svc_llm_proxy
-          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel|TestAgentRespondsToThreadMessageViaLLMProxy
+          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel|TestFullPipelineAgnMessageResponse
 
       - name: Upload E2E artifacts
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           E2E_SUITES: go-core
           E2E_TAGS: svc_agents_orchestrator svc_llm_proxy
-          E2E_GO_TEST_RUN: TestLLMProxyGatewayCreatedModel|TestAgentRespondsToThreadMessageViaLLMProxy
+          E2E_GO_TEST_RUN: TestAgentRespondsToThreadMessageViaLLMProxy
 
       - name: Upload E2E artifacts
         if: always()

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -89,16 +89,9 @@ functions:
     export AGN_INIT_IMAGE="${AGN_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
     export CLAUDE_INIT_IMAGE="${CLAUDE_INIT_IMAGE:-ghcr.io/agynio/agent-init-claude:latest}"
     export AGN_EXPOSE_INIT_IMAGE="${AGN_EXPOSE_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
-    test_tags=(svc_llm_proxy)
-    if [ -n "${E2E_TAGS:-}" ]; then
-      read -r -a test_tags <<< "${E2E_TAGS}"
-    fi
-    test_args=()
-    for tag in "${test_tags[@]}"; do
-      test_args+=(--tag "${tag}")
-    done
+    test_tags="${E2E_TAGS:-svc_llm_proxy}"
     LLM_PROXY_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
-      devspace run test-e2e "${test_args[@]}"
+      devspace run test-e2e $(for tag in ${test_tags}; do printf ' --tag %s' "${tag}"; done)
 
 commands:
   test-e2e: |-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -90,7 +90,9 @@ functions:
     export CLAUDE_INIT_IMAGE="${CLAUDE_INIT_IMAGE:-ghcr.io/agynio/agent-init-claude:latest}"
     export AGN_EXPOSE_INIT_IMAGE="${AGN_EXPOSE_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
     test_tags="${E2E_TAGS:-svc_llm_proxy}"
+    test_suites="${E2E_SUITES:-go-core}"
     LLM_PROXY_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
+      E2E_SUITES="${test_suites}" \
       devspace run test-e2e $(for tag in ${test_tags}; do printf ' --tag %s' "${tag}"; done)
 
 commands:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -89,8 +89,16 @@ functions:
     export AGN_INIT_IMAGE="${AGN_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
     export CLAUDE_INIT_IMAGE="${CLAUDE_INIT_IMAGE:-ghcr.io/agynio/agent-init-claude:latest}"
     export AGN_EXPOSE_INIT_IMAGE="${AGN_EXPOSE_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
+    test_tags=(svc_llm_proxy)
+    if [ -n "${E2E_TAGS:-}" ]; then
+      read -r -a test_tags <<< "${E2E_TAGS}"
+    fi
+    test_args=()
+    for tag in "${test_tags[@]}"; do
+      test_args+=(--tag "${tag}")
+    done
     LLM_PROXY_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
-      devspace run test-e2e --tag svc_llm_proxy
+      devspace run test-e2e "${test_args[@]}"
 
 commands:
   test-e2e: |-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -81,6 +81,12 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
+  patch_agents_orchestrator: |-
+    echo "Patching agents-orchestrator to target llm-proxy service..."
+    kubectl set env deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} \
+      AGENT_LLM_BASE_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080/v1
+    kubectl rollout status deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} --timeout=120s
+
   run_llm_proxy_e2e: |-
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
@@ -124,6 +130,7 @@ pipelines:
       disable_argocd_sync
       patch_deployment
       run_pipelines --background ci-e2e-source
+      patch_agents_orchestrator
       run_llm_proxy_e2e
   ci-e2e-source:
     run: |-

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -38,6 +38,23 @@ func Middleware(zitiResolver IdentityResolver, apiTokenResolver BearerTokenResol
 }
 
 func resolveIdentity(ctx context.Context, authHeader string, zitiResolver IdentityResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
+	accessToken, bearerOK := httpauth.ExtractBearerToken(authHeader)
+	if bearerOK {
+		if !apitokenresolver.HasPrefix(accessToken) {
+			return ctx, errors.New("unsupported bearer token")
+		}
+		if apiTokenResolver == nil {
+			return ctx, errors.New("api token resolver is not configured")
+		}
+
+		resolved, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
+		if err != nil {
+			return ctx, err
+		}
+
+		return identity.WithIdentity(ctx, resolved), nil
+	}
+
 	sourceIdentity, ok := ziticonn.SourceIdentityFromContext(ctx)
 	if ok {
 		if zitiResolver == nil {
@@ -50,21 +67,5 @@ func resolveIdentity(ctx context.Context, authHeader string, zitiResolver Identi
 		return identity.WithIdentity(ctx, resolved), nil
 	}
 
-	accessToken, ok := httpauth.ExtractBearerToken(authHeader)
-	if !ok {
-		return ctx, errors.New("authorization required")
-	}
-	if !apitokenresolver.HasPrefix(accessToken) {
-		return ctx, errors.New("unsupported bearer token")
-	}
-	if apiTokenResolver == nil {
-		return ctx, errors.New("api token resolver is not configured")
-	}
-
-	resolved, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
-	if err != nil {
-		return ctx, err
-	}
-
-	return identity.WithIdentity(ctx, resolved), nil
+	return ctx, errors.New("authorization required")
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agynio/llm-proxy/internal/identity"
+	"github.com/agynio/llm-proxy/internal/ziticonn"
+)
+
+type stubIdentityResolver struct {
+	resolved identity.ResolvedIdentity
+	called   bool
+}
+
+func (r *stubIdentityResolver) ResolveIdentity(context.Context, string) (identity.ResolvedIdentity, error) {
+	r.called = true
+	return r.resolved, nil
+}
+
+type stubBearerResolver struct {
+	resolved identity.ResolvedIdentity
+	called   bool
+	err      error
+}
+
+func (r *stubBearerResolver) ResolveFromToken(context.Context, string) (identity.ResolvedIdentity, error) {
+	r.called = true
+	if r.err != nil {
+		return identity.ResolvedIdentity{}, r.err
+	}
+	return r.resolved, nil
+}
+
+func TestResolveIdentityPrefersBearerTokenOverZitiSourceIdentity(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	resolvedCtx, err := resolveIdentity(ctx, "Bearer agyn_test-token", zitiResolver, apiTokenResolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !apiTokenResolver.called {
+		t.Fatal("expected api token resolver to be called")
+	}
+	if zitiResolver.called {
+		t.Fatal("expected ziti resolver not to be called")
+	}
+
+	resolved, ok := identity.IdentityFromContext(resolvedCtx)
+	if !ok {
+		t.Fatal("resolved identity missing from context")
+	}
+	if resolved.IdentityID != "user-1" || resolved.IdentityType != identity.IdentityTypeUser {
+		t.Fatalf("unexpected identity: %+v", resolved)
+	}
+}
+
+func TestResolveIdentityUsesZitiWhenBearerMissing(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	resolvedCtx, err := resolveIdentity(ctx, "", zitiResolver, apiTokenResolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !zitiResolver.called {
+		t.Fatal("expected ziti resolver to be called")
+	}
+	if apiTokenResolver.called {
+		t.Fatal("expected api token resolver not to be called")
+	}
+
+	resolved, ok := identity.IdentityFromContext(resolvedCtx)
+	if !ok {
+		t.Fatal("resolved identity missing from context")
+	}
+	if resolved.IdentityID != "agent-1" || resolved.IdentityType != identity.IdentityTypeAgent {
+		t.Fatalf("unexpected identity: %+v", resolved)
+	}
+}
+
+func TestResolveIdentityReturnsBearerTokenErrorBeforeZitiFallback(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{err: errors.New("invalid token")}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	_, err := resolveIdentity(ctx, "Bearer agyn_invalid", zitiResolver, apiTokenResolver)
+	if err == nil || err.Error() != "invalid token" {
+		t.Fatalf("expected invalid token error, got %v", err)
+	}
+	if !apiTokenResolver.called {
+		t.Fatal("expected api token resolver to be called")
+	}
+	if zitiResolver.called {
+		t.Fatal("expected ziti resolver not to be called")
+	}
+}


### PR DESCRIPTION
## Summary
- Updates llm-proxy E2E workflow to run only the go-core suite.
- Runs the existing gateway-created model test and the companion go-core thread message → agent response test from `agynio/e2e` branch `noa/issue-57`.
- Adds POSIX-sh-compatible `E2E_TAGS` and `E2E_SUITES` plumbing in `devspace.yaml` so CI does not select Playwright/UI suites.
- Mitigates bootstrap provisioning flakes by logging into GHCR, pre-pulling `ghcr.io/k3d-io/k3d-tools:5.7.5` with retries, and exporting `K3D_IMAGE_TOOLS` so k3d avoids `:latest` during cluster creation.
- Keeps existing E2E artifact upload behavior unchanged.

Closes #57.
Depends on agynio/e2e#105.

## Tests
- `nix shell nixpkgs#gcc -c bash -c 'go test -count=1 ./... && go vet ./...'`
  - llm-proxy unit tests: 37 passed, 0 failed, 0 skipped.
  - lint/vet passed with no errors.
- `nix shell nixpkgs#gcc nixpkgs#buf -c bash -c 'cd /workspace/e2e/suites/go-core && buf generate && go test -count=1 -tags "e2e svc_agents_orchestrator svc_llm_proxy" -run "TestLLMProxyURLDefaultUsesIngress|TestLLMProxyURLExplicitOverride|TestLLMGatewayConnectEndpointPath" ./tests && go test -count=1 -tags "e2e svc_agents_orchestrator svc_llm_proxy" -run "^$" ./tests && go vet -tags "e2e svc_agents_orchestrator svc_llm_proxy" ./tests'`
  - e2e helper tests: 3 passed, 0 failed, 0 skipped.
  - e2e compile-only check: 0 passed, 0 failed, 0 skipped.
  - lint/vet passed with no errors.