### PR TITLE
fix(auth): accept x-api-key tokens

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/agynio/llm-proxy/internal/apitokenresolver"
 	"github.com/agynio/llm-proxy/internal/httpauth"
@@ -26,7 +27,10 @@ func Middleware(zitiResolver IdentityResolver, apiTokenResolver BearerTokenResol
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, err := resolveIdentity(r.Context(), r.Header.Get("Authorization"), zitiResolver, apiTokenResolver)
+			ctx, err := resolveIdentity(r.Context(), proxyAuthHeaders{
+				authorization: r.Header.Get("Authorization"),
+				xAPIKey:       r.Header.Get("x-api-key"),
+			}, zitiResolver, apiTokenResolver)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
@@ -37,22 +41,20 @@ func Middleware(zitiResolver IdentityResolver, apiTokenResolver BearerTokenResol
 	}
 }
 
-func resolveIdentity(ctx context.Context, authHeader string, zitiResolver IdentityResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
-	accessToken, bearerOK := httpauth.ExtractBearerToken(authHeader)
+type proxyAuthHeaders struct {
+	authorization string
+	xAPIKey       string
+}
+
+func resolveIdentity(ctx context.Context, headers proxyAuthHeaders, zitiResolver IdentityResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
+	accessToken, bearerOK := httpauth.ExtractBearerToken(headers.authorization)
 	if bearerOK {
-		if !apitokenresolver.HasPrefix(accessToken) {
-			return ctx, errors.New("unsupported bearer token")
-		}
-		if apiTokenResolver == nil {
-			return ctx, errors.New("api token resolver is not configured")
-		}
+		return resolveAPIToken(ctx, accessToken, apiTokenResolver)
+	}
 
-		resolved, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
-		if err != nil {
-			return ctx, err
-		}
-
-		return identity.WithIdentity(ctx, resolved), nil
+	apiKey := strings.TrimSpace(headers.xAPIKey)
+	if apiKey != "" {
+		return resolveAPIToken(ctx, apiKey, apiTokenResolver)
 	}
 
 	sourceIdentity, ok := ziticonn.SourceIdentityFromContext(ctx)
@@ -68,4 +70,20 @@ func resolveIdentity(ctx context.Context, authHeader string, zitiResolver Identi
 	}
 
 	return ctx, errors.New("authorization required")
+}
+
+func resolveAPIToken(ctx context.Context, accessToken string, apiTokenResolver BearerTokenResolver) (context.Context, error) {
+	if !apitokenresolver.HasPrefix(accessToken) {
+		return ctx, errors.New("unsupported api token")
+	}
+	if apiTokenResolver == nil {
+		return ctx, errors.New("api token resolver is not configured")
+	}
+
+	resolved, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
+	if err != nil {
+		return ctx, err
+	}
+
+	return identity.WithIdentity(ctx, resolved), nil
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -33,12 +33,12 @@ func (r *stubBearerResolver) ResolveFromToken(context.Context, string) (identity
 	return r.resolved, nil
 }
 
-func TestResolveIdentityPrefersBearerTokenOverZitiSourceIdentity(t *testing.T) {
+func TestResolveIdentityPrefersAuthorizationBearerOverZitiSourceIdentity(t *testing.T) {
 	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
 	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
 
 	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
-	resolvedCtx, err := resolveIdentity(ctx, "Bearer agyn_test-token", zitiResolver, apiTokenResolver)
+	resolvedCtx, err := resolveIdentity(ctx, proxyAuthHeaders{authorization: "Bearer agyn_test-token"}, zitiResolver, apiTokenResolver)
 	if err != nil {
 		t.Fatalf("resolve identity: %v", err)
 	}
@@ -58,12 +58,52 @@ func TestResolveIdentityPrefersBearerTokenOverZitiSourceIdentity(t *testing.T) {
 	}
 }
 
-func TestResolveIdentityUsesZitiWhenBearerMissing(t *testing.T) {
+func TestResolveIdentityUsesXAPIKeyWhenBearerMissing(t *testing.T) {
 	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
 	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
 
 	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
-	resolvedCtx, err := resolveIdentity(ctx, "", zitiResolver, apiTokenResolver)
+	resolvedCtx, err := resolveIdentity(ctx, proxyAuthHeaders{xAPIKey: " agyn_api-key-token "}, zitiResolver, apiTokenResolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !apiTokenResolver.called {
+		t.Fatal("expected api token resolver to be called")
+	}
+	if zitiResolver.called {
+		t.Fatal("expected ziti resolver not to be called")
+	}
+
+	resolved, ok := identity.IdentityFromContext(resolvedCtx)
+	if !ok {
+		t.Fatal("resolved identity missing from context")
+	}
+	if resolved.IdentityID != "user-1" || resolved.IdentityType != identity.IdentityTypeUser {
+		t.Fatalf("unexpected identity: %+v", resolved)
+	}
+}
+
+func TestResolveIdentityPrefersAuthorizationBearerOverXAPIKey(t *testing.T) {
+	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
+
+	_, err := resolveIdentity(context.Background(), proxyAuthHeaders{
+		authorization: "Bearer agyn_bearer-token",
+		xAPIKey:       "not-agyn-token",
+	}, nil, apiTokenResolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !apiTokenResolver.called {
+		t.Fatal("expected api token resolver to be called")
+	}
+}
+
+func TestResolveIdentityUsesZitiWhenHTTPAuthMissing(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	resolvedCtx, err := resolveIdentity(ctx, proxyAuthHeaders{}, zitiResolver, apiTokenResolver)
 	if err != nil {
 		t.Fatalf("resolve identity: %v", err)
 	}
@@ -88,7 +128,24 @@ func TestResolveIdentityReturnsBearerTokenErrorBeforeZitiFallback(t *testing.T) 
 	apiTokenResolver := &stubBearerResolver{err: errors.New("invalid token")}
 
 	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
-	_, err := resolveIdentity(ctx, "Bearer agyn_invalid", zitiResolver, apiTokenResolver)
+	_, err := resolveIdentity(ctx, proxyAuthHeaders{authorization: "Bearer agyn_invalid"}, zitiResolver, apiTokenResolver)
+	if err == nil || err.Error() != "invalid token" {
+		t.Fatalf("expected invalid token error, got %v", err)
+	}
+	if !apiTokenResolver.called {
+		t.Fatal("expected api token resolver to be called")
+	}
+	if zitiResolver.called {
+		t.Fatal("expected ziti resolver not to be called")
+	}
+}
+
+func TestResolveIdentityReturnsXAPIKeyErrorBeforeZitiFallback(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{err: errors.New("invalid token")}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	_, err := resolveIdentity(ctx, proxyAuthHeaders{xAPIKey: "agyn_invalid"}, zitiResolver, apiTokenResolver)
 	if err == nil || err.Error() != "invalid token" {
 		t.Fatalf("expected invalid token error, got %v", err)
 	}

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -46,3 +46,13 @@ func TestAuthValidToken(t *testing.T) {
 		t.Fatalf("expected non-401 status, got %d", resp.StatusCode)
 	}
 }
+
+func TestAuthValidXAPIKey(t *testing.T) {
+	client := newXAPIKeyClient(testAPIToken)
+	resp := doPost(t, client, responsesURL(), requestBody(t, testModelID, "hi", false))
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Fatalf("expected non-401 status, got %d", resp.StatusCode)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -58,7 +58,22 @@ func newAuthenticatedClient(token string) *http.Client {
 	}
 }
 
+func newXAPIKeyClient(token string) *http.Client {
+	return &http.Client{
+		Timeout: proxyTimeout,
+		Transport: xAPIKeyTransport{
+			token: token,
+			base:  http.DefaultTransport,
+		},
+	}
+}
+
 type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+type xAPIKeyTransport struct {
 	token string
 	base  http.RoundTripper
 }
@@ -66,6 +81,12 @@ type bearerTransport struct {
 func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clone := req.Clone(req.Context())
 	clone.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(clone)
+}
+
+func (t xAPIKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("x-api-key", t.token)
 	return t.base.RoundTrip(clone)
 }
 


### PR DESCRIPTION
## Summary
- Accept platform API tokens from the caller-facing `x-api-key` header in addition to `Authorization: Bearer`.
- Preserve precedence: `Authorization: Bearer` is used first, then `x-api-key`, then OpenZiti identity.
- Add unit coverage and an in-cluster E2E auth test for `x-api-key` authentication.

Root-cause investigation for agynio/e2e#124 found chat-app agent replies failing after bootstrap moved to llm-proxy `0.12.2`. The 0.12.2 auth change made bearer tokens take precedence over Ziti, but llm-proxy still only parsed API tokens from `Authorization`. Codex/agn clients send `OPENAI_API_KEY`/configured API keys as `x-api-key`, so agent LLM requests over `llm-proxy.ziti` were authenticated as the Ziti agent identity instead of the injected user API token and then failed model authorization. This PR implements the documented proxy auth contract.

References agynio/e2e#124.

## Tests
- `go test -count=1 ./...`
  - package tests passed locally; 6 packages had no test files.
- `go test -c -tags e2e ./test/e2e`
  - E2E package compile check passed; not executed outside cluster.
- `go vet ./... && go vet -tags e2e ./test/e2e`
  - lint/vet passed with no errors.

Note: Direct `go test -count=1 -tags e2e -run 'TestAuthValidXAPIKey' ./test/e2e` correctly failed outside the E2E cluster at dialing in-cluster services (`users:50051`); compile validation was used locally.