### PR TITLE
Fix agent model authorization principal

### DIFF
--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -14,8 +14,9 @@ type stubIdentityResolver struct {
 	called   bool
 }
 
-func (r *stubIdentityResolver) ResolveIdentity(context.Context, string) (identity.ResolvedIdentity, error) {
+func (r *stubIdentityResolver) ResolveIdentity(_ context.Context, sourceIdentity string) (identity.ResolvedIdentity, error) {
 	r.called = true
+	r.resolved.ZitiID = sourceIdentity
 	return r.resolved, nil
 }
 
@@ -80,6 +81,9 @@ func TestResolveIdentityUsesZitiWhenBearerMissing(t *testing.T) {
 	}
 	if resolved.IdentityID != "agent-1" || resolved.IdentityType != identity.IdentityTypeAgent {
 		t.Fatalf("unexpected identity: %+v", resolved)
+	}
+	if resolved.ZitiID != "ziti-agent-identity" {
+		t.Fatalf("expected ziti id to be preserved, got %q", resolved.ZitiID)
 	}
 }
 

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -18,6 +18,8 @@ const (
 type ResolvedIdentity struct {
 	IdentityID   string
 	IdentityType IdentityType
+	WorkloadID   string
+	ZitiID       string
 }
 
 func ParseIdentityType(value string) (IdentityType, error) {

--- a/internal/identity/metadata.go
+++ b/internal/identity/metadata.go
@@ -11,6 +11,8 @@ import (
 const (
 	MetadataKeyIdentityID   = "x-identity-id"
 	MetadataKeyIdentityType = "x-identity-type"
+	MetadataKeyWorkloadID   = "x-workload-id"
+	MetadataKeyZitiID       = "x-ziti-identity-id"
 )
 
 func AppendToOutgoingContext(ctx context.Context) context.Context {
@@ -19,11 +21,18 @@ func AppendToOutgoingContext(ctx context.Context) context.Context {
 		return ctx
 	}
 
-	return metadata.AppendToOutgoingContext(
-		ctx,
+	pairs := []string{
 		MetadataKeyIdentityID, resolved.IdentityID,
 		MetadataKeyIdentityType, string(resolved.IdentityType),
-	)
+	}
+	if resolved.WorkloadID != "" {
+		pairs = append(pairs, MetadataKeyWorkloadID, resolved.WorkloadID)
+	}
+	if resolved.ZitiID != "" {
+		pairs = append(pairs, MetadataKeyZitiID, resolved.ZitiID)
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, pairs...)
 }
 
 func IdentityFromIncomingContext(ctx context.Context) (ResolvedIdentity, error) {
@@ -49,7 +58,20 @@ func IdentityFromIncomingContext(ctx context.Context) (ResolvedIdentity, error) 
 	return ResolvedIdentity{
 		IdentityID:   identityID,
 		IdentityType: identityType,
+		WorkloadID:   optionalMetadataValue(md, MetadataKeyWorkloadID),
+		ZitiID:       optionalMetadataValue(md, MetadataKeyZitiID),
 	}, nil
+}
+
+func optionalMetadataValue(md metadata.MD, key string) string {
+	values := md.Get(key)
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func requiredMetadataValue(md metadata.MD, key string) (string, error) {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -114,9 +114,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeProxyError(w, err)
 		return
 	}
-	log.Printf("proxy: resolved model remote_name=%s endpoint=%s", providerConfig.remoteName, providerConfig.endpoint)
+	log.Printf(
+		"proxy: resolved model model_id=%s organization_id=%s provider_organization_id=%s remote_name=%s endpoint=%s",
+		modelID,
+		providerConfig.organizationID,
+		providerConfig.organizationID,
+		providerConfig.remoteName,
+		providerConfig.endpoint,
+	)
 
-	if err := h.authorizeRequest(r.Context(), resolvedIdentity, modelID); err != nil {
+	if err := h.authorizeRequest(r.Context(), resolvedIdentity, providerConfig, modelID); err != nil {
 		writeProxyError(w, err)
 		return
 	}
@@ -218,24 +225,84 @@ func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *ht
 	h.recordMetering(meta, usage, meteringStatusSuccess)
 }
 
-func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.ResolvedIdentity, modelID string) error {
-	user := fmt.Sprintf("identity:%s", resolved.IdentityID)
+func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.ResolvedIdentity, provider providerConfig, modelID string) error {
+	principalID := authorizationPrincipalID(resolved)
+	user := fmt.Sprintf("identity:%s", principalID)
 	object := fmt.Sprintf("model:%s", modelID)
+	tuple := &authorizationv1.TupleKey{
+		User:     user,
+		Relation: "can_use",
+		Object:   object,
+	}
+	log.Printf(
+		"proxy: authorization check principal_identity_id=%s principal_identity_type=%s principal_workload_id=%s principal_ziti_identity_id=%s model_id=%s resolved_model_id=%s organization_id=%s provider_organization_id=%s tuple_user=%s tuple_relation=%s tuple_object=%s",
+		resolved.IdentityID,
+		resolved.IdentityType,
+		resolved.WorkloadID,
+		resolved.ZitiID,
+		modelID,
+		modelID,
+		provider.organizationID,
+		provider.organizationID,
+		tuple.User,
+		tuple.Relation,
+		tuple.Object,
+	)
 
 	resp, err := h.authzClient.Check(ctx, &authorizationv1.CheckRequest{
-		TupleKey: &authorizationv1.TupleKey{
-			User:     user,
-			Relation: "can_use",
-			Object:   object,
-		},
+		TupleKey: tuple,
 	})
 	if err != nil {
+		log.Printf(
+			"proxy: authorization check error principal_identity_id=%s principal_identity_type=%s principal_workload_id=%s principal_ziti_identity_id=%s model_id=%s organization_id=%s tuple_user=%s tuple_relation=%s tuple_object=%s err=%v",
+			resolved.IdentityID,
+			resolved.IdentityType,
+			resolved.WorkloadID,
+			resolved.ZitiID,
+			modelID,
+			provider.organizationID,
+			tuple.User,
+			tuple.Relation,
+			tuple.Object,
+			err,
+		)
 		return err
 	}
 	if !resp.GetAllowed() {
+		log.Printf(
+			"proxy: authorization denied principal_identity_id=%s principal_identity_type=%s principal_workload_id=%s principal_ziti_identity_id=%s model_id=%s organization_id=%s tuple_user=%s tuple_relation=%s tuple_object=%s",
+			resolved.IdentityID,
+			resolved.IdentityType,
+			resolved.WorkloadID,
+			resolved.ZitiID,
+			modelID,
+			provider.organizationID,
+			tuple.User,
+			tuple.Relation,
+			tuple.Object,
+		)
 		return ErrForbidden
 	}
+	log.Printf(
+		"proxy: authorization allowed principal_identity_id=%s principal_identity_type=%s principal_workload_id=%s principal_ziti_identity_id=%s model_id=%s organization_id=%s tuple_user=%s tuple_relation=%s tuple_object=%s",
+		resolved.IdentityID,
+		resolved.IdentityType,
+		resolved.WorkloadID,
+		resolved.ZitiID,
+		modelID,
+		provider.organizationID,
+		tuple.User,
+		tuple.Relation,
+		tuple.Object,
+	)
 	return nil
+}
+
+func authorizationPrincipalID(resolved identity.ResolvedIdentity) string {
+	if resolved.IdentityType == identity.IdentityTypeAgent && resolved.WorkloadID != "" {
+		return resolved.WorkloadID
+	}
+	return resolved.IdentityID
 }
 
 type providerConfig struct {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -150,6 +150,64 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	}
 }
 
+func TestHandlerAuthorizesAgentWithWorkloadPrincipal(t *testing.T) {
+	modelID := uuid.New()
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer provider.Close()
+
+	llmClient := &fakeLLMClient{resp: &llmv1.ResolveModelResponse{
+		Endpoint:       provider.URL,
+		Token:          "provider-token",
+		RemoteName:     "remote-model",
+		OrganizationId: "org-1",
+		Protocol:       llmv1.Protocol_PROTOCOL_RESPONSES,
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
+	}}
+	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
+	handler := NewHandler(llmClient, authzClient, &fakeMeteringClient{}, provider.Client())
+
+	body := `{"model":"` + modelID.String() + `","stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
+	ctx := identity.WithIdentity(req.Context(), identity.ResolvedIdentity{
+		IdentityID:   "agent-1",
+		IdentityType: identity.IdentityTypeAgent,
+		WorkloadID:   "workload-1",
+		ZitiID:       "ziti-agent-1",
+	})
+	req = req.WithContext(ctx)
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+	tuple := authzClient.lastReq.GetTupleKey()
+	if tuple.GetUser() != "identity:workload-1" {
+		t.Fatalf("expected workload authz user, got %q", tuple.GetUser())
+	}
+	if tuple.GetRelation() != "can_use" {
+		t.Fatalf("unexpected authz relation %q", tuple.GetRelation())
+	}
+	if tuple.GetObject() != "model:"+modelID.String() {
+		t.Fatalf("unexpected authz object %q", tuple.GetObject())
+	}
+}
+
+func TestAuthorizationPrincipalIDUsesAgentIdentityWhenWorkloadMissing(t *testing.T) {
+	principalID := authorizationPrincipalID(identity.ResolvedIdentity{
+		IdentityID:   "agent-1",
+		IdentityType: identity.IdentityTypeAgent,
+	})
+	if principalID != "agent-1" {
+		t.Fatalf("expected agent identity fallback, got %q", principalID)
+	}
+}
+
 func TestHandlerForwardStream(t *testing.T) {
 	modelID := uuid.New()
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/zitimgmtclient/client.go
+++ b/internal/zitimgmtclient/client.go
@@ -99,6 +99,8 @@ func (c *Client) ResolveIdentity(ctx context.Context, sourceIdentity string) (id
 	return identity.ResolvedIdentity{
 		IdentityID:   identityID,
 		IdentityType: identityType,
+		WorkloadID:   strings.TrimSpace(response.GetWorkloadId()),
+		ZitiID:       trimmed,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Adds llm-proxy authorization diagnostics for the exact OpenFGA check tuple: `user`, `relation`, and `object`.
- Logs the resolved principal components: `identity_id`, `identity_type`, workload ID, Ziti identity ID, resolved model ID, organization ID, and provider organization ID.
- Preserves workload and Ziti identity data from Ziti management resolution and forwards optional identity metadata across gRPC calls.
- Fixes agent authorization to check `identity:<workload_id>` when an agent request has a resolved workload ID; non-agent callers and agent calls without workload metadata continue using the resolved identity ID.

Fixes agynio/chat-app#96.

## What the existing failure logs show
- Failed chat-app e2e artifacts show the agent workload repeatedly receiving `unexpected status 403 Forbidden: access denied` from `http://llm-proxy.ziti/v1/responses`.
- Existing llm-proxy logs only showed model resolution (`remote_name=simple-hello`, TestLLM endpoint) followed by `proxy: error status=403 err=access denied`, without the principal or tuple being checked.
- Based on ziti-management, agent Ziti identities resolve to both an agent identity ID and a workload ID. This PR makes those values visible and authorizes agent model use against the workload principal expected for the runtime caller.

## Test & Lint Summary
- `git diff --check`: passed with no whitespace errors.
- `go test ./internal/proxy ./internal/auth ./internal/identity ./internal/zitimgmtclient`: 2 packages passed, 2 packages had no test files, 0 failed, 0 skipped.
- `go test ./...`: 4 packages passed, remaining packages had no test files, 0 failed, 0 skipped.
- `go vet ./...`: passed with no errors.
- `go build ./...`: passed.