### PR TITLE
Fix agent authorization principal for LLM proxy

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -299,9 +299,6 @@ func (h *Handler) authorizeRequest(ctx context.Context, resolved identity.Resolv
 }
 
 func authorizationPrincipalID(resolved identity.ResolvedIdentity) string {
-	if resolved.IdentityType == identity.IdentityTypeAgent && resolved.WorkloadID != "" {
-		return resolved.WorkloadID
-	}
 	return resolved.IdentityID
 }
 

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -150,7 +150,7 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	}
 }
 
-func TestHandlerAuthorizesAgentWithWorkloadPrincipal(t *testing.T) {
+func TestHandlerAuthorizesAgentWithIdentityPrincipal(t *testing.T) {
 	modelID := uuid.New()
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -187,8 +187,8 @@ func TestHandlerAuthorizesAgentWithWorkloadPrincipal(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.Code)
 	}
 	tuple := authzClient.lastReq.GetTupleKey()
-	if tuple.GetUser() != "identity:workload-1" {
-		t.Fatalf("expected workload authz user, got %q", tuple.GetUser())
+	if tuple.GetUser() != "identity:agent-1" {
+		t.Fatalf("expected agent authz user, got %q", tuple.GetUser())
 	}
 	if tuple.GetRelation() != "can_use" {
 		t.Fatalf("unexpected authz relation %q", tuple.GetRelation())
@@ -198,13 +198,14 @@ func TestHandlerAuthorizesAgentWithWorkloadPrincipal(t *testing.T) {
 	}
 }
 
-func TestAuthorizationPrincipalIDUsesAgentIdentityWhenWorkloadMissing(t *testing.T) {
+func TestAuthorizationPrincipalIDUsesAgentIdentityEvenWhenWorkloadPresent(t *testing.T) {
 	principalID := authorizationPrincipalID(identity.ResolvedIdentity{
 		IdentityID:   "agent-1",
 		IdentityType: identity.IdentityTypeAgent,
+		WorkloadID:   "workload-1",
 	})
 	if principalID != "agent-1" {
-		t.Fatalf("expected agent identity fallback, got %q", principalID)
+		t.Fatalf("expected agent identity, got %q", principalID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- authorize LLM Proxy model access with the resolved platform identity id instead of runtime workload id
- update proxy tests to assert agent identities are used even when OpenZiti resolution includes a workload id

## Root cause
Agents are organization members as `identity:<agent_id>`, and LLM models grant `can_use` via `member from org`. Runtime workload ids are not organization members, so using `workload_id` as the authorization principal caused real agent LLM calls to fail with 403.

## Tests
- `buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1`
- `go test ./internal/proxy ./internal/auth ./internal/apitokenresolver ./internal/identity ./internal/zitimgmtclient`

## Note
I attempted local bootstrap provisioning, but the local environment repeatedly timed out pulling registry images (for example `quay.io/argoproj/argocd:v3.3.1`) before platform services came up.
