### PR TITLE
fix(auth): fall back to ziti when bearer auth fails

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/agynio/llm-proxy/internal/apitokenresolver"
@@ -40,19 +41,23 @@ func Middleware(zitiResolver IdentityResolver, apiTokenResolver BearerTokenResol
 func resolveIdentity(ctx context.Context, authHeader string, zitiResolver IdentityResolver, apiTokenResolver BearerTokenResolver) (context.Context, error) {
 	accessToken, bearerOK := httpauth.ExtractBearerToken(authHeader)
 	if bearerOK {
-		if !apitokenresolver.HasPrefix(accessToken) {
-			return ctx, errors.New("unsupported bearer token")
-		}
-		if apiTokenResolver == nil {
+		if apitokenresolver.HasPrefix(accessToken) && apiTokenResolver != nil {
+			resolved, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
+			if err == nil {
+				return identity.WithIdentity(ctx, resolved), nil
+			}
+			if _, ok := ziticonn.SourceIdentityFromContext(ctx); !ok {
+				return ctx, err
+			}
+			log.Printf("auth: api token resolution failed; falling back to ziti identity: %v", err)
+		} else if _, ok := ziticonn.SourceIdentityFromContext(ctx); !ok {
+			if !apitokenresolver.HasPrefix(accessToken) {
+				return ctx, errors.New("unsupported bearer token")
+			}
 			return ctx, errors.New("api token resolver is not configured")
+		} else {
+			log.Printf("auth: bearer token is unsupported for api-token auth; falling back to ziti identity")
 		}
-
-		resolved, err := apiTokenResolver.ResolveFromToken(ctx, accessToken)
-		if err != nil {
-			return ctx, err
-		}
-
-		return identity.WithIdentity(ctx, resolved), nil
 	}
 
 	sourceIdentity, ok := ziticonn.SourceIdentityFromContext(ctx)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -34,7 +34,7 @@ func (r *stubBearerResolver) ResolveFromToken(context.Context, string) (identity
 	return r.resolved, nil
 }
 
-func TestResolveIdentityPrefersBearerTokenOverZitiSourceIdentity(t *testing.T) {
+func TestResolveIdentityPrefersValidBearerTokenOverZitiSourceIdentity(t *testing.T) {
 	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
 	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
 
@@ -55,6 +55,59 @@ func TestResolveIdentityPrefersBearerTokenOverZitiSourceIdentity(t *testing.T) {
 		t.Fatal("resolved identity missing from context")
 	}
 	if resolved.IdentityID != "user-1" || resolved.IdentityType != identity.IdentityTypeUser {
+		t.Fatalf("unexpected identity: %+v", resolved)
+	}
+}
+
+func TestResolveIdentityFallsBackToZitiWhenBearerTokenInvalid(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{err: errors.New("invalid token")}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	resolvedCtx, err := resolveIdentity(ctx, "Bearer agyn_invalid", zitiResolver, apiTokenResolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if !apiTokenResolver.called {
+		t.Fatal("expected api token resolver to be called")
+	}
+	if !zitiResolver.called {
+		t.Fatal("expected ziti resolver to be called")
+	}
+
+	resolved, ok := identity.IdentityFromContext(resolvedCtx)
+	if !ok {
+		t.Fatal("resolved identity missing from context")
+	}
+	if resolved.IdentityID != "agent-1" || resolved.IdentityType != identity.IdentityTypeAgent {
+		t.Fatalf("unexpected identity: %+v", resolved)
+	}
+	if resolved.ZitiID != "ziti-agent-identity" {
+		t.Fatalf("expected ziti id to be preserved, got %q", resolved.ZitiID)
+	}
+}
+
+func TestResolveIdentityFallsBackToZitiWhenBearerTokenUnsupported(t *testing.T) {
+	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
+	apiTokenResolver := &stubBearerResolver{resolved: identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser}}
+
+	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
+	resolvedCtx, err := resolveIdentity(ctx, "Bearer sk-test-token", zitiResolver, apiTokenResolver)
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if apiTokenResolver.called {
+		t.Fatal("expected api token resolver not to be called")
+	}
+	if !zitiResolver.called {
+		t.Fatal("expected ziti resolver to be called")
+	}
+
+	resolved, ok := identity.IdentityFromContext(resolvedCtx)
+	if !ok {
+		t.Fatal("resolved identity missing from context")
+	}
+	if resolved.IdentityID != "agent-1" || resolved.IdentityType != identity.IdentityTypeAgent {
 		t.Fatalf("unexpected identity: %+v", resolved)
 	}
 }
@@ -87,12 +140,11 @@ func TestResolveIdentityUsesZitiWhenBearerMissing(t *testing.T) {
 	}
 }
 
-func TestResolveIdentityReturnsBearerTokenErrorBeforeZitiFallback(t *testing.T) {
+func TestResolveIdentityReturnsBearerTokenErrorWhenZitiMissing(t *testing.T) {
 	zitiResolver := &stubIdentityResolver{resolved: identity.ResolvedIdentity{IdentityID: "agent-1", IdentityType: identity.IdentityTypeAgent}}
 	apiTokenResolver := &stubBearerResolver{err: errors.New("invalid token")}
 
-	ctx := ziticonn.WithSourceIdentity(context.Background(), "ziti-agent-identity")
-	_, err := resolveIdentity(ctx, "Bearer agyn_invalid", zitiResolver, apiTokenResolver)
+	_, err := resolveIdentity(context.Background(), "Bearer agyn_invalid", zitiResolver, apiTokenResolver)
 	if err == nil || err.Error() != "invalid token" {
 		t.Fatalf("expected invalid token error, got %v", err)
 	}


### PR DESCRIPTION
## Summary\n- Keep valid agyn_ bearer tokens taking precedence.\n- If bearer auth is invalid or unsupported and the connection has a Ziti source identity, fall back to Ziti auth instead of failing at the bearer path.\n- Preserve bearer-auth errors when no Ziti identity is present.\n\n## Why\nIn-cluster agents authenticate to llm-proxy by Ziti. Some SDKs may still send stale or irrelevant Authorization headers. Those headers should not break otherwise-valid Ziti-authenticated requests.\n\n## Validation\n- CGO_ENABLED=0 go test ./internal/auth ./internal/proxy\n- go test ./internal/auth ./internal/proxy attempted, but environment lacks gcc for cgo.\n