### PR TITLE
Fix llm-proxy e2e identity metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           buf generate buf.build/agynio/api \
             --path agynio/api/llm/v1 \
             --path agynio/api/users/v1 \
+            --path agynio/api/organizations/v1 \
             --path agynio/api/authorization/v1 \
             --path agynio/api/metering/v1 \
             --path agynio/api/ziti_management/v1 \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,13 +22,13 @@ jobs:
         uses: agynio/bootstrap/.github/actions/provision@main
 
       - name: Setup DevSpace
-        uses: agynio/e2e/.github/actions/setup-devspace@main
+        uses: agynio/e2e/.github/actions/setup-devspace@4c6ec5c5025ee6ad63ca0e8c0c3b2ba898108dc3
 
       - name: Checkout E2E repository
         uses: actions/checkout@v4
         with:
           repository: agynio/e2e
-          ref: main
+          ref: 4c6ec5c5025ee6ad63ca0e8c0c3b2ba898108dc3
           path: e2e
 
       - name: Run llm-proxy E2E

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY buf.gen.yaml buf.yaml ./
 RUN buf generate buf.build/agynio/api \
       --path agynio/api/llm/v1 \
       --path agynio/api/users/v1 \
+      --path agynio/api/organizations/v1 \
       --path agynio/api/authorization/v1 \
       --path agynio/api/metering/v1 \
       --path agynio/api/ziti_management/v1 \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -83,9 +83,9 @@ functions:
     EOF
     )"
   patch_agents_orchestrator: |-
-    echo "Patching agents-orchestrator to target llm-proxy service..."
+    echo "Patching agents-orchestrator to target llm-proxy over Ziti..."
     kubectl set env deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} \
-      AGENT_LLM_BASE_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080/v1
+      AGENT_LLM_BASE_URL=http://llm-proxy.ziti/v1
     kubectl rollout status deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} --timeout=120s
 
   run_llm_proxy_e2e: |-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -54,6 +54,7 @@ functions:
                   buf generate buf.build/agynio/api \
                     --path agynio/api/llm/v1 \
                     --path agynio/api/users/v1 \
+                    --path agynio/api/organizations/v1 \
                     --path agynio/api/authorization/v1 \
                     --path agynio/api/metering/v1 \
                     --path agynio/api/ziti_management/v1 \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -89,6 +89,51 @@ functions:
     kubectl rollout status deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} --timeout=120s
 
   run_llm_proxy_e2e: |-
+    bootstrap_dir="${GITHUB_WORKSPACE:-$(pwd)}/bootstrap"
+    k8s_stack="${bootstrap_dir}/stacks/k8s"
+    platform_stack="${bootstrap_dir}/stacks/platform"
+    apps_stack="${bootstrap_dir}/stacks/apps"
+
+    if [ -z "${AGYN_BASE_URL:-}" ]; then
+      if [ ! -d "${k8s_stack}" ]; then
+        echo "ERROR: AGYN_BASE_URL is not set and ${k8s_stack} does not exist." >&2
+        exit 1
+      fi
+      domain="$(terraform -chdir="${k8s_stack}" output -raw domain)"
+      ingress_port="$(terraform -chdir="${k8s_stack}" output -raw ingress_port)"
+      if [ -z "${domain}" ] || [ -z "${ingress_port}" ]; then
+        echo "ERROR: Bootstrap k8s outputs domain or ingress_port are empty." >&2
+        exit 1
+      fi
+      export AGYN_BASE_URL="https://gateway.${domain}:${ingress_port}"
+    fi
+
+    if [ -z "${AGYN_API_TOKEN:-}" ]; then
+      if [ ! -d "${platform_stack}" ]; then
+        echo "ERROR: AGYN_API_TOKEN is not set and ${platform_stack} does not exist." >&2
+        exit 1
+      fi
+      AGYN_API_TOKEN="$(terraform -chdir="${platform_stack}" output -raw cluster_admin_api_token)"
+      if [ -z "${AGYN_API_TOKEN}" ]; then
+        echo "ERROR: Terraform output cluster_admin_api_token is empty." >&2
+        exit 1
+      fi
+      export AGYN_API_TOKEN
+    fi
+
+    if [ -z "${AGYN_ORGANIZATION_ID:-}" ]; then
+      if [ ! -d "${apps_stack}" ]; then
+        echo "ERROR: AGYN_ORGANIZATION_ID is not set and ${apps_stack} does not exist." >&2
+        exit 1
+      fi
+      AGYN_ORGANIZATION_ID="$(terraform -chdir="${apps_stack}" output -raw bootstrap_organization_id)"
+      if [ -z "${AGYN_ORGANIZATION_ID}" ]; then
+        echo "ERROR: Terraform output bootstrap_organization_id is empty." >&2
+        exit 1
+      fi
+      export AGYN_ORGANIZATION_ID
+    fi
+
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
     export CODEX_INIT_IMAGE="${CODEX_INIT_IMAGE:-ghcr.io/agynio/agent-init-codex:latest}"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -119,6 +119,107 @@ functions:
       export AGYN_ORGANIZATION_ID
     fi
 
+    if [ -z "${AGYN_MODEL_ID:-}" ]; then
+      gateway_setup_url="${AGYN_BASE_URL:-}"
+      if [ -z "${gateway_setup_url}" ]; then
+        k8s_stack="${bootstrap_dir}/stacks/k8s"
+        if [ ! -d "${k8s_stack}" ]; then
+          echo "ERROR: AGYN_MODEL_ID is not set and ${k8s_stack} does not exist." >&2
+          exit 1
+        fi
+        domain="$(terraform -chdir="${k8s_stack}" output -raw domain)"
+        ingress_port="$(terraform -chdir="${k8s_stack}" output -raw ingress_port)"
+        if [ -z "${domain}" ] || [ -z "${ingress_port}" ]; then
+          echo "ERROR: Bootstrap k8s outputs domain or ingress_port are empty." >&2
+          exit 1
+        fi
+        gateway_setup_url="https://gateway.${domain}:${ingress_port}"
+      fi
+
+      list_models_payload=$(cat <<EOF
+    {"organizationId":"${AGYN_ORGANIZATION_ID}","llmProviderId":"","pageSize":200,"pageToken":""}
+    EOF
+      )
+      model_id="$(curl -fsS -k \
+        -H 'Content-Type: application/json' \
+        -H 'Connect-Protocol-Version: 1' \
+        -H "Authorization: Bearer ${AGYN_API_TOKEN}" \
+        -d "${list_models_payload}" \
+        "${gateway_setup_url}/agynio.api.gateway.v1.LLMGateway/ListModels" \
+        | python3 -c "$(cat <<'PY'
+    import json
+    import sys
+
+    payload = json.load(sys.stdin)
+    for model in payload.get("models") or []:
+        meta = model.get("meta") or {}
+        model_id = meta.get("id") or model.get("id") or ""
+        if model_id:
+            print(model_id)
+            break
+    PY
+    )")"
+
+      if [ -z "${model_id}" ]; then
+        now="$(date +%s)"
+        create_provider_payload=$(cat <<EOF
+    {"endpoint":"https://testllm.dev/v1/org/agynio/suite/agn/responses","authMethod":"AUTH_METHOD_BEARER","token":"e2e-token-${now}","organizationId":"${AGYN_ORGANIZATION_ID}","protocol":"PROTOCOL_RESPONSES"}
+    EOF
+        )
+        provider_id="$(curl -fsS -k \
+          -H 'Content-Type: application/json' \
+          -H 'Connect-Protocol-Version: 1' \
+          -H "Authorization: Bearer ${AGYN_API_TOKEN}" \
+          -d "${create_provider_payload}" \
+          "${gateway_setup_url}/agynio.api.gateway.v1.LLMGateway/CreateLLMProvider" \
+          | python3 -c "$(cat <<'PY'
+    import json
+    import sys
+
+    payload = json.load(sys.stdin)
+    provider = payload.get("provider") or {}
+    meta = provider.get("meta") or {}
+    provider_id = meta.get("id") or provider.get("id") or ""
+    if provider_id:
+        print(provider_id)
+    PY
+    )")"
+        if [ -z "${provider_id}" ]; then
+          echo "ERROR: CreateLLMProvider did not return an id." >&2
+          exit 1
+        fi
+
+        create_model_payload=$(cat <<EOF
+    {"name":"E2E LLM Proxy Model ${now}","llmProviderId":"${provider_id}","remoteName":"simple-hello","organizationId":"${AGYN_ORGANIZATION_ID}"}
+    EOF
+        )
+        model_id="$(curl -fsS -k \
+          -H 'Content-Type: application/json' \
+          -H 'Connect-Protocol-Version: 1' \
+          -H "Authorization: Bearer ${AGYN_API_TOKEN}" \
+          -d "${create_model_payload}" \
+          "${gateway_setup_url}/agynio.api.gateway.v1.LLMGateway/CreateModel" \
+          | python3 -c "$(cat <<'PY'
+    import json
+    import sys
+
+    payload = json.load(sys.stdin)
+    model = payload.get("model") or {}
+    meta = model.get("meta") or {}
+    model_id = meta.get("id") or model.get("id") or ""
+    if model_id:
+        print(model_id)
+    PY
+    )")"
+      fi
+
+      if [ -z "${model_id}" ]; then
+        echo "ERROR: Unable to determine AGYN_MODEL_ID." >&2
+        exit 1
+      fi
+      export AGYN_MODEL_ID="${model_id}"
+    fi
+
     cd e2e
     export AGYN_AGENT_IMAGE="${AGYN_AGENT_IMAGE:-ghcr.io/agynio/agent-runtime:v1.0.0}"
     export CODEX_INIT_IMAGE="${CODEX_INIT_IMAGE:-ghcr.io/agynio/agent-init-codex:latest}"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -90,23 +90,8 @@ functions:
 
   run_llm_proxy_e2e: |-
     bootstrap_dir="${GITHUB_WORKSPACE:-$(pwd)}/bootstrap"
-    k8s_stack="${bootstrap_dir}/stacks/k8s"
     platform_stack="${bootstrap_dir}/stacks/platform"
     apps_stack="${bootstrap_dir}/stacks/apps"
-
-    if [ -z "${AGYN_BASE_URL:-}" ]; then
-      if [ ! -d "${k8s_stack}" ]; then
-        echo "ERROR: AGYN_BASE_URL is not set and ${k8s_stack} does not exist." >&2
-        exit 1
-      fi
-      domain="$(terraform -chdir="${k8s_stack}" output -raw domain)"
-      ingress_port="$(terraform -chdir="${k8s_stack}" output -raw ingress_port)"
-      if [ -z "${domain}" ] || [ -z "${ingress_port}" ]; then
-        echo "ERROR: Bootstrap k8s outputs domain or ingress_port are empty." >&2
-        exit 1
-      fi
-      export AGYN_BASE_URL="https://gateway.${domain}:${ingress_port}"
-    fi
 
     if [ -z "${AGYN_API_TOKEN:-}" ]; then
       if [ ! -d "${platform_stack}" ]; then

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -189,8 +189,8 @@ func createOrganization(ctx context.Context, client organizationsv1.Organization
 func createModel(ctx context.Context, client llmv1.LLMServiceClient, identityID string, orgID string, name string) (string, string, error) {
 	callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
 	defer cancel()
-
 	callCtx = withIdentity(callCtx, identityID)
+
 	providerResp, err := client.CreateLLMProvider(callCtx, &llmv1.CreateLLMProviderRequest{
 		Endpoint:       llmProviderEndpoint,
 		Token:          "not-needed",

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	authorizationv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/authorization/v1"
 	organizationsv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/organizations/v1"
 	usersv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
@@ -28,6 +29,7 @@ import (
 const (
 	defaultUsersAddr         = "users:50051"
 	defaultOrganizationsAddr = "organizations:50051"
+	defaultAuthorizationAddr = "authorization:50051"
 	defaultGatewayBaseURL    = "http://gateway-gateway.platform.svc.cluster.local:8080"
 	setupTimeout             = 30 * time.Second
 	apiTokenName             = "e2e-llm-proxy"
@@ -36,6 +38,8 @@ const (
 	metadataIdentityIDKey    = "x-identity-id"
 	metadataIdentityTypeKey  = "x-identity-type"
 	identityTypeUser         = "user"
+	clusterAdminIdentityID   = "a3c1e9d2-7f4b-5e1a-9c3d-2b8f6a4e7d10"
+	modelAccessRelation      = "can_use"
 )
 
 var (
@@ -47,6 +51,7 @@ var (
 func setupFixtures(ctx context.Context) (func(), error) {
 	usersAddr := envOrDefault("USERS_ADDR", defaultUsersAddr)
 	orgAddr := envOrDefault("ORGANIZATIONS_ADDR", defaultOrganizationsAddr)
+	authzAddr := envOrDefault("AUTHORIZATION_ADDR", envOrDefault("AUTHORIZATION_ADDRESS", defaultAuthorizationAddr))
 	gatewayBaseURL, err := parseGatewayBaseURL(envOrDefault("AGYN_BASE_URL", defaultGatewayBaseURL))
 	if err != nil {
 		return nil, err
@@ -108,8 +113,21 @@ func setupFixtures(ctx context.Context) (func(), error) {
 	}
 	testUnauthorizedModelID = unauthorizedModelID
 
+	authzConn, err := grpc.NewClient(authzAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("connect authorization service: %w", err)
+	}
+	defer authzConn.Close()
+	authzClient := authorizationv1.NewAuthorizationServiceClient(authzConn)
+
+	modelAccess := modelAccessTuple(identityID, modelID)
+	if err := grantModelAccess(ctx, authzClient, modelAccess); err != nil {
+		return nil, err
+	}
+
 	cleanup := func() {
 		cleanupCtx := context.Background()
+		cleanupModelAccess(cleanupCtx, authzAddr, modelAccess)
 		cleanupLLM(cleanupCtx, gatewayBaseURL, []llmCleanupSpec{
 			{modelID: testModelID, providerID: providerID, apiToken: apiToken},
 			{modelID: testUnauthorizedModelID, providerID: unauthorizedProviderID, apiToken: unauthorizedAPIToken},
@@ -236,15 +254,65 @@ func withIdentity(ctx context.Context, identityID string) context.Context {
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
+func withClusterAdminIdentity(ctx context.Context) context.Context {
+	return withIdentity(ctx, clusterAdminIdentityID)
+}
+
 type orgCleanupSpec struct {
 	organizationID string
 	identityID     string
+}
+
+type modelAccessSpec struct {
+	identityID string
+	modelID    string
 }
 
 type llmCleanupSpec struct {
 	modelID    string
 	providerID string
 	apiToken   string
+}
+
+func grantModelAccess(ctx context.Context, client authorizationv1.AuthorizationServiceClient, spec modelAccessSpec) error {
+	callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
+	defer cancel()
+	_, err := client.Write(withClusterAdminIdentity(callCtx), &authorizationv1.WriteRequest{
+		Writes: []*authorizationv1.TupleKey{modelAccessTupleKey(spec)},
+	})
+	if err != nil {
+		return fmt.Errorf("grant model access: %w", err)
+	}
+	return nil
+}
+
+func cleanupModelAccess(ctx context.Context, addr string, spec modelAccessSpec) {
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		logCleanupError("connect authorization service", err)
+		return
+	}
+	defer conn.Close()
+	client := authorizationv1.NewAuthorizationServiceClient(conn)
+
+	callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
+	defer cancel()
+	_, err = client.Write(withClusterAdminIdentity(callCtx), &authorizationv1.WriteRequest{
+		Deletes: []*authorizationv1.TupleKey{modelAccessTupleKey(spec)},
+	})
+	logCleanupError("delete model access", err)
+}
+
+func modelAccessTuple(identityID string, modelID string) modelAccessSpec {
+	return modelAccessSpec{identityID: identityID, modelID: modelID}
+}
+
+func modelAccessTupleKey(spec modelAccessSpec) *authorizationv1.TupleKey {
+	return &authorizationv1.TupleKey{
+		User:     "identity:" + spec.identityID,
+		Relation: modelAccessRelation,
+		Object:   "model:" + spec.modelID,
+	}
 }
 
 func cleanupAPIToken(ctx context.Context, addr string, identityID string, tokenID string) {

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -22,11 +22,14 @@ import (
 
 const (
 	defaultUsersAddr         = "users:50051"
-	defaultOrganizationsAddr = "tenants:50051"
+	defaultOrganizationsAddr = "organizations:50051"
 	defaultLLMAddr           = "llm:50051"
 	setupTimeout             = 30 * time.Second
 	apiTokenName             = "e2e-llm-proxy"
 	llmProviderEndpoint      = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	metadataIdentityIDKey    = "x-identity-id"
+	metadataIdentityTypeKey  = "x-identity-type"
+	identityTypeUser         = "user"
 )
 
 var (
@@ -87,13 +90,13 @@ func setupFixtures(ctx context.Context) (func(), error) {
 	defer llmConn.Close()
 	llmClient := llmv1.NewLLMServiceClient(llmConn)
 
-	modelID, providerID, err := createModel(ctx, llmClient, orgID, "e2e-simple-hello")
+	modelID, providerID, err := createModel(ctx, llmClient, identityID, orgID, "e2e-simple-hello")
 	if err != nil {
 		return nil, err
 	}
 	testModelID = modelID
 
-	unauthorizedModelID, unauthorizedProviderID, err := createModel(ctx, llmClient, unauthorizedOrgID, "e2e-simple-hello-unauthorized")
+	unauthorizedModelID, unauthorizedProviderID, err := createModel(ctx, llmClient, unauthorizedIdentityID, unauthorizedOrgID, "e2e-simple-hello-unauthorized")
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +104,10 @@ func setupFixtures(ctx context.Context) (func(), error) {
 
 	cleanup := func() {
 		cleanupCtx := context.Background()
-		cleanupLLM(cleanupCtx, llmAddr, []string{testModelID, testUnauthorizedModelID}, []string{providerID, unauthorizedProviderID})
+		cleanupLLM(cleanupCtx, llmAddr, []llmCleanupSpec{
+			{modelID: testModelID, providerID: providerID, identityID: identityID},
+			{modelID: testUnauthorizedModelID, providerID: unauthorizedProviderID, identityID: unauthorizedIdentityID},
+		})
 		cleanupOrganizations(cleanupCtx, orgAddr, []orgCleanupSpec{
 			{organizationID: orgID, identityID: identityID},
 			{organizationID: unauthorizedOrgID, identityID: unauthorizedIdentityID},
@@ -180,10 +186,11 @@ func createOrganization(ctx context.Context, client organizationsv1.Organization
 	return orgID, nil
 }
 
-func createModel(ctx context.Context, client llmv1.LLMServiceClient, orgID string, name string) (string, string, error) {
+func createModel(ctx context.Context, client llmv1.LLMServiceClient, identityID string, orgID string, name string) (string, string, error) {
 	callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
 	defer cancel()
 
+	callCtx = withIdentity(callCtx, identityID)
 	providerResp, err := client.CreateLLMProvider(callCtx, &llmv1.CreateLLMProviderRequest{
 		Endpoint:       llmProviderEndpoint,
 		Token:          "not-needed",
@@ -221,13 +228,22 @@ func createModel(ctx context.Context, client llmv1.LLMServiceClient, orgID strin
 }
 
 func withIdentity(ctx context.Context, identityID string) context.Context {
-	md := metadata.New(map[string]string{"x-identity-id": identityID})
+	md := metadata.New(map[string]string{
+		metadataIdentityIDKey:   identityID,
+		metadataIdentityTypeKey: identityTypeUser,
+	})
 	return metadata.NewOutgoingContext(ctx, md)
 }
 
 type orgCleanupSpec struct {
 	organizationID string
 	identityID     string
+}
+
+type llmCleanupSpec struct {
+	modelID    string
+	providerID string
+	identityID string
 }
 
 func cleanupAPIToken(ctx context.Context, addr string, identityID string, tokenID string) {
@@ -270,7 +286,7 @@ func cleanupOrganizations(ctx context.Context, addr string, specs []orgCleanupSp
 	}
 }
 
-func cleanupLLM(ctx context.Context, addr string, modelIDs []string, providerIDs []string) {
+func cleanupLLM(ctx context.Context, addr string, specs []llmCleanupSpec) {
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		logCleanupError("connect llm service", err)
@@ -279,22 +295,24 @@ func cleanupLLM(ctx context.Context, addr string, modelIDs []string, providerIDs
 	defer conn.Close()
 	client := llmv1.NewLLMServiceClient(conn)
 
-	for _, modelID := range modelIDs {
-		if modelID == "" {
+	for _, spec := range specs {
+		if spec.modelID == "" {
 			continue
 		}
 		callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
-		_, err := client.DeleteModel(callCtx, &llmv1.DeleteModelRequest{Id: modelID})
+		callCtx = withIdentity(callCtx, spec.identityID)
+		_, err := client.DeleteModel(callCtx, &llmv1.DeleteModelRequest{Id: spec.modelID})
 		cancel()
 		logCleanupError("delete model", err)
 	}
 
-	for _, providerID := range providerIDs {
-		if providerID == "" {
+	for _, spec := range specs {
+		if spec.providerID == "" {
 			continue
 		}
 		callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
-		_, err := client.DeleteLLMProvider(callCtx, &llmv1.DeleteLLMProviderRequest{Id: providerID})
+		callCtx = withIdentity(callCtx, spec.identityID)
+		_, err := client.DeleteLLMProvider(callCtx, &llmv1.DeleteLLMProviderRequest{Id: spec.providerID})
 		cancel()
 		logCleanupError("delete llm provider", err)
 	}

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -3,13 +3,18 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
-	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
 	organizationsv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/organizations/v1"
 	usersv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/users/v1"
 	"github.com/google/uuid"
@@ -23,10 +28,11 @@ import (
 const (
 	defaultUsersAddr         = "users:50051"
 	defaultOrganizationsAddr = "organizations:50051"
-	defaultLLMAddr           = "llm:50051"
+	defaultGatewayBaseURL    = "http://gateway-gateway.platform.svc.cluster.local:8080"
 	setupTimeout             = 30 * time.Second
 	apiTokenName             = "e2e-llm-proxy"
 	llmProviderEndpoint      = "https://testllm.dev/v1/org/agynio/suite/agn/responses"
+	llmGatewayServicePath    = "agynio.api.gateway.v1.LLMGateway"
 	metadataIdentityIDKey    = "x-identity-id"
 	metadataIdentityTypeKey  = "x-identity-type"
 	identityTypeUser         = "user"
@@ -41,7 +47,10 @@ var (
 func setupFixtures(ctx context.Context) (func(), error) {
 	usersAddr := envOrDefault("USERS_ADDR", defaultUsersAddr)
 	orgAddr := envOrDefault("ORGANIZATIONS_ADDR", defaultOrganizationsAddr)
-	llmAddr := envOrDefault("LLM_ADDR", defaultLLMAddr)
+	gatewayBaseURL, err := parseGatewayBaseURL(envOrDefault("AGYN_BASE_URL", defaultGatewayBaseURL))
+	if err != nil {
+		return nil, err
+	}
 
 	usersConn, err := grpc.NewClient(usersAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -83,20 +92,17 @@ func setupFixtures(ctx context.Context) (func(), error) {
 		return nil, err
 	}
 
-	llmConn, err := grpc.NewClient(llmAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, fmt.Errorf("connect llm service: %w", err)
-	}
-	defer llmConn.Close()
-	llmClient := llmv1.NewLLMServiceClient(llmConn)
-
-	modelID, providerID, err := createModel(ctx, llmClient, identityID, orgID, "e2e-simple-hello")
+	modelID, providerID, err := createModel(ctx, gatewayBaseURL, apiToken, orgID, "e2e-simple-hello")
 	if err != nil {
 		return nil, err
 	}
 	testModelID = modelID
 
-	unauthorizedModelID, unauthorizedProviderID, err := createModel(ctx, llmClient, unauthorizedIdentityID, unauthorizedOrgID, "e2e-simple-hello-unauthorized")
+	unauthorizedAPIToken, unauthorizedAPITokenID, err := createAPIToken(ctx, usersClient, unauthorizedIdentityID, apiTokenName+"-unauthorized")
+	if err != nil {
+		return nil, err
+	}
+	unauthorizedModelID, unauthorizedProviderID, err := createModel(ctx, gatewayBaseURL, unauthorizedAPIToken, unauthorizedOrgID, "e2e-simple-hello-unauthorized")
 	if err != nil {
 		return nil, err
 	}
@@ -104,14 +110,15 @@ func setupFixtures(ctx context.Context) (func(), error) {
 
 	cleanup := func() {
 		cleanupCtx := context.Background()
-		cleanupLLM(cleanupCtx, llmAddr, []llmCleanupSpec{
-			{modelID: testModelID, providerID: providerID, identityID: identityID},
-			{modelID: testUnauthorizedModelID, providerID: unauthorizedProviderID, identityID: unauthorizedIdentityID},
+		cleanupLLM(cleanupCtx, gatewayBaseURL, []llmCleanupSpec{
+			{modelID: testModelID, providerID: providerID, apiToken: apiToken},
+			{modelID: testUnauthorizedModelID, providerID: unauthorizedProviderID, apiToken: unauthorizedAPIToken},
 		})
 		cleanupOrganizations(cleanupCtx, orgAddr, []orgCleanupSpec{
 			{organizationID: orgID, identityID: identityID},
 			{organizationID: unauthorizedOrgID, identityID: unauthorizedIdentityID},
 		})
+		cleanupAPIToken(cleanupCtx, usersAddr, unauthorizedIdentityID, unauthorizedAPITokenID)
 		cleanupAPIToken(cleanupCtx, usersAddr, identityID, apiTokenID)
 	}
 
@@ -186,41 +193,35 @@ func createOrganization(ctx context.Context, client organizationsv1.Organization
 	return orgID, nil
 }
 
-func createModel(ctx context.Context, client llmv1.LLMServiceClient, identityID string, orgID string, name string) (string, string, error) {
+func createModel(ctx context.Context, gatewayBaseURL string, apiToken string, orgID string, name string) (string, string, error) {
 	callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
 	defer cancel()
-	callCtx = withIdentity(callCtx, identityID)
 
-	providerResp, err := client.CreateLLMProvider(callCtx, &llmv1.CreateLLMProviderRequest{
-		Endpoint:       llmProviderEndpoint,
-		Token:          "not-needed",
-		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
-		OrganizationId: orgID,
+	providerResp, err := postGatewayConnect[gatewayCreateLLMProviderResponse](callCtx, gatewayBaseURL, apiToken, "CreateLLMProvider", map[string]string{
+		"endpoint":       llmProviderEndpoint,
+		"token":          "not-needed",
+		"authMethod":     "AUTH_METHOD_BEARER",
+		"organizationId": orgID,
+		"protocol":       "PROTOCOL_RESPONSES",
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("create llm provider: %w", err)
 	}
-	if providerResp == nil || providerResp.GetProvider() == nil || providerResp.GetProvider().GetMeta() == nil {
-		return "", "", fmt.Errorf("create llm provider: missing provider metadata")
-	}
-	providerID := strings.TrimSpace(providerResp.GetProvider().GetMeta().GetId())
+	providerID := strings.TrimSpace(providerResp.Provider.Meta.ID)
 	if providerID == "" {
 		return "", "", fmt.Errorf("create llm provider: id missing")
 	}
 
-	modelResp, err := client.CreateModel(callCtx, &llmv1.CreateModelRequest{
-		Name:           name,
-		LlmProviderId:  providerID,
-		RemoteName:     "simple-hello",
-		OrganizationId: orgID,
+	modelResp, err := postGatewayConnect[gatewayCreateModelResponse](callCtx, gatewayBaseURL, apiToken, "CreateModel", map[string]string{
+		"name":           name,
+		"llmProviderId":  providerID,
+		"remoteName":     "simple-hello",
+		"organizationId": orgID,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("create model %s: %w", name, err)
 	}
-	if modelResp == nil || modelResp.GetModel() == nil || modelResp.GetModel().GetMeta() == nil {
-		return "", "", fmt.Errorf("create model %s: missing model metadata", name)
-	}
-	modelID := strings.TrimSpace(modelResp.GetModel().GetMeta().GetId())
+	modelID := strings.TrimSpace(modelResp.Model.Meta.ID)
 	if modelID == "" {
 		return "", "", fmt.Errorf("create model %s: id missing", name)
 	}
@@ -243,7 +244,7 @@ type orgCleanupSpec struct {
 type llmCleanupSpec struct {
 	modelID    string
 	providerID string
-	identityID string
+	apiToken   string
 }
 
 func cleanupAPIToken(ctx context.Context, addr string, identityID string, tokenID string) {
@@ -286,24 +287,14 @@ func cleanupOrganizations(ctx context.Context, addr string, specs []orgCleanupSp
 	}
 }
 
-func cleanupLLM(ctx context.Context, addr string, specs []llmCleanupSpec) {
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		logCleanupError("connect llm service", err)
-		return
-	}
-	defer conn.Close()
-	client := llmv1.NewLLMServiceClient(conn)
-
+func cleanupLLM(ctx context.Context, gatewayBaseURL string, specs []llmCleanupSpec) {
 	for _, spec := range specs {
 		if spec.modelID == "" {
 			continue
 		}
 		callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
-		callCtx = withIdentity(callCtx, spec.identityID)
-		_, err := client.DeleteModel(callCtx, &llmv1.DeleteModelRequest{Id: spec.modelID})
+		postGatewayConnectBestEffort(callCtx, gatewayBaseURL, spec.apiToken, "DeleteModel", map[string]string{"id": spec.modelID})
 		cancel()
-		logCleanupError("delete model", err)
 	}
 
 	for _, spec := range specs {
@@ -311,11 +302,112 @@ func cleanupLLM(ctx context.Context, addr string, specs []llmCleanupSpec) {
 			continue
 		}
 		callCtx, cancel := context.WithTimeout(ctx, setupTimeout)
-		callCtx = withIdentity(callCtx, spec.identityID)
-		_, err := client.DeleteLLMProvider(callCtx, &llmv1.DeleteLLMProviderRequest{Id: spec.providerID})
+		postGatewayConnectBestEffort(callCtx, gatewayBaseURL, spec.apiToken, "DeleteLLMProvider", map[string]string{"id": spec.providerID})
 		cancel()
-		logCleanupError("delete llm provider", err)
 	}
+}
+
+func postGatewayConnect[T any](ctx context.Context, gatewayBaseURL string, apiToken string, method string, payload any) (T, error) {
+	var response T
+	body, statusCode, err := postGatewayConnectRaw(ctx, gatewayBaseURL, apiToken, method, payload)
+	if err != nil {
+		return response, err
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return response, fmt.Errorf("gateway %s failed with status %d: %s", method, statusCode, body)
+	}
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		return response, fmt.Errorf("decode gateway %s response: %w", method, err)
+	}
+	return response, nil
+}
+
+func postGatewayConnectBestEffort(ctx context.Context, gatewayBaseURL string, apiToken string, method string, payload any) {
+	_, _, _ = postGatewayConnectRaw(ctx, gatewayBaseURL, apiToken, method, payload)
+}
+
+func postGatewayConnectRaw(ctx context.Context, gatewayBaseURL string, apiToken string, method string, payload any) (string, int, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", 0, fmt.Errorf("marshal gateway %s request: %w", method, err)
+	}
+
+	endpoint, err := gatewayLLMConnectEndpoint(gatewayBaseURL, method)
+	if err != nil {
+		return "", 0, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", 0, fmt.Errorf("build gateway %s request: %w", method, err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Connect-Protocol-Version", "1")
+	request.Header.Set("Authorization", "Bearer "+apiToken)
+
+	response, err := gatewayHTTPClient(gatewayBaseURL).Do(request)
+	if err != nil {
+		return "", 0, fmt.Errorf("post gateway %s: %w", method, err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", 0, fmt.Errorf("read gateway %s response: %w", method, err)
+	}
+	return strings.TrimSpace(string(responseBody)), response.StatusCode, nil
+}
+
+func gatewayLLMConnectEndpoint(gatewayBaseURL string, method string) (string, error) {
+	return url.JoinPath(gatewayBaseURL, llmGatewayServicePath, method)
+}
+
+func gatewayHTTPClient(gatewayBaseURL string) *http.Client {
+	transport := http.DefaultTransport
+	parsed, err := url.Parse(gatewayBaseURL)
+	if err == nil && parsed.Scheme == "https" {
+		baseTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			panic("unexpected default transport type")
+		}
+		cloned := baseTransport.Clone()
+		cloned.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		transport = cloned
+	}
+	return &http.Client{Timeout: setupTimeout, Transport: transport}
+}
+
+func parseGatewayBaseURL(value string) (string, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(value), "/")
+	if baseURL == "" {
+		return "", fmt.Errorf("AGYN_BASE_URL empty")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse AGYN_BASE_URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("AGYN_BASE_URL must start with http or https")
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("AGYN_BASE_URL missing host")
+	}
+	return baseURL, nil
+}
+
+type gatewayCreateLLMProviderResponse struct {
+	Provider gatewayLLMEntity `json:"provider"`
+}
+
+type gatewayCreateModelResponse struct {
+	Model gatewayLLMEntity `json:"model"`
+}
+
+type gatewayLLMEntity struct {
+	Meta gatewayEntityMeta `json:"meta"`
+}
+
+type gatewayEntityMeta struct {
+	ID string `json:"id"`
 }
 
 func logCleanupError(action string, err error) {


### PR DESCRIPTION
## Summary
- Export Gateway E2E authentication env from bootstrap Terraform outputs before running `devspace run test-e2e`.
- Preserve caller-provided `AGYN_BASE_URL`, `AGYN_API_TOKEN`, and `AGYN_ORGANIZATION_ID` overrides for local runs.
- Keep llm-proxy local e2e fixture setup aligned with identity-aware LLM RPCs.

Fixes #64

## Tests
- `buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 --path agynio/api/metering/v1 --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --path agynio/api/organizations/v1`
- `go test -tags e2e -c ./test/e2e -o /tmp/llm-proxy-e2e.test`
- `go vet ./...`
- `go test -json ./...`
