### PR TITLE
fix(proxy): handle gzip provider responses

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -70,6 +70,9 @@ functions:
                 limits:
                   cpu: "2"
                   memory: 4Gi
+              livenessProbe: null
+              readinessProbe: null
+              startupProbe: null
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -229,6 +229,8 @@ functions:
     export AGN_EXPOSE_INIT_IMAGE="${AGN_EXPOSE_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
     test_tags="${E2E_TAGS:-svc_llm_proxy}"
     test_suites="${E2E_SUITES:-go-core}"
+    gateway_base_url="${AGYN_BASE_URL:-http://gateway.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080}"
+    AGYN_BASE_URL="${gateway_base_url}" \
     LLM_PROXY_URL=http://llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
       E2E_SUITES="${test_suites}" \
       devspace run test-e2e $(for tag in ${test_tags}; do printf ' --tag %s' "${tag}"; done)

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -26,7 +26,7 @@ functions:
     fi
   patch_deployment: |-
     echo "Patching llm-proxy deployment for DevSpace..."
-    kubectl patch deployment llm-proxy-llm-proxy -n ${LLM_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment llm-proxy -n ${LLM_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -229,7 +229,7 @@ functions:
     export AGN_EXPOSE_INIT_IMAGE="${AGN_EXPOSE_INIT_IMAGE:-ghcr.io/agynio/agent-init-agn:latest}"
     test_tags="${E2E_TAGS:-svc_llm_proxy}"
     test_suites="${E2E_SUITES:-go-core}"
-    LLM_PROXY_URL=http://llm-proxy-llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
+    LLM_PROXY_URL=http://llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local:8080 \
       E2E_SUITES="${test_suites}" \
       devspace run test-e2e $(for tag in ${test_tags}; do printf ' --tag %s' "${tag}"; done)
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -47,7 +47,7 @@ functions:
                 - |
                   set -eu
                   elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
+                  while [ ! -f /opt/app/data/go.mod ] || [ ! -f /opt/app/data/go.sum ]; do
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -91,6 +91,38 @@ functions:
       AGENT_LLM_BASE_URL=http://llm-proxy.ziti/v1
     kubectl rollout status deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} --timeout=120s
   wait_llm_proxy_http: |-
+    echo "Waiting for llm-proxy source pod to start..."
+    source_pod=""
+    for attempt in $(seq 1 180); do
+      source_pod="$(kubectl get pods -n ${LLM_PROXY_NAMESPACE} \
+        -l app.kubernetes.io/name=llm-proxy,app.kubernetes.io/instance=llm-proxy \
+        -o go-template='{{range .items}}{{if eq (index .spec.containers 0).image "ghcr.io/agynio/devcontainer-go:1"}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' \
+        | sed -n '1p')"
+      if [ -n "${source_pod}" ]; then
+        break
+      fi
+      sleep 2
+    done
+    if [ -z "${source_pod}" ]; then
+      echo "ERROR: llm-proxy source pod was not created." >&2
+      exit 1
+    fi
+
+    echo "Waiting for llm-proxy source pod ${source_pod} to listen..."
+    for attempt in $(seq 1 300); do
+      if kubectl logs -n ${LLM_PROXY_NAMESPACE} "${source_pod}" -c llm-proxy --tail=80 2>/dev/null \
+        | grep -q "llm-proxy listening on :8080"; then
+        break
+      fi
+      sleep 2
+    done
+    if ! kubectl logs -n ${LLM_PROXY_NAMESPACE} "${source_pod}" -c llm-proxy --tail=80 2>/dev/null \
+      | grep -q "llm-proxy listening on :8080"; then
+      echo "ERROR: llm-proxy source pod did not start listening." >&2
+      kubectl logs -n ${LLM_PROXY_NAMESPACE} "${source_pod}" -c llm-proxy --tail=120 || true
+      exit 1
+    fi
+
     echo "Waiting for llm-proxy HTTP service to accept connections..."
     kubectl run llm-proxy-http-wait -n ${LLM_PROXY_NAMESPACE} \
       --rm \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -47,7 +47,22 @@ functions:
                 - |
                   set -eu
                   elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ] || [ ! -f /opt/app/data/go.sum ]; do
+                  while [ ! -f /opt/app/data/go.mod ] \
+                    || [ ! -f /opt/app/data/go.sum ] \
+                    || [ ! -f /opt/app/data/cmd/llm-proxy/main.go ] \
+                    || [ ! -f /opt/app/data/internal/apitokenresolver/resolver.go ] \
+                    || [ ! -f /opt/app/data/internal/auth/middleware.go ] \
+                    || [ ! -f /opt/app/data/internal/config/config.go ] \
+                    || [ ! -f /opt/app/data/internal/grpcclient/client.go ] \
+                    || [ ! -f /opt/app/data/internal/grpcclient/interceptors.go ] \
+                    || [ ! -f /opt/app/data/internal/httpauth/bearer.go ] \
+                    || [ ! -f /opt/app/data/internal/identity/identity.go ] \
+                    || [ ! -f /opt/app/data/internal/identity/metadata.go ] \
+                    || [ ! -f /opt/app/data/internal/proxy/handler.go ] \
+                    || [ ! -f /opt/app/data/internal/proxy/metering.go ] \
+                    || [ ! -f /opt/app/data/internal/ziticonn/conn.go ] \
+                    || [ ! -f /opt/app/data/internal/zitimanager/manager.go ] \
+                    || [ ! -f /opt/app/data/internal/zitimgmtclient/client.go ]; do
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -90,6 +90,26 @@ functions:
     kubectl set env deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} \
       AGENT_LLM_BASE_URL=http://llm-proxy.ziti/v1
     kubectl rollout status deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} --timeout=120s
+  wait_llm_proxy_http: |-
+    echo "Waiting for llm-proxy HTTP service to accept connections..."
+    kubectl run llm-proxy-http-wait -n ${LLM_PROXY_NAMESPACE} \
+      --rm \
+      --attach \
+      --restart=Never \
+      --image=busybox:1.37.0 \
+      -- sh -c "$(cat <<EOF
+    set -eu
+    for attempt in \$(seq 1 120); do
+      if nc -z -w 2 llm-proxy.${LLM_PROXY_NAMESPACE}.svc.cluster.local 8080; then
+        echo "llm-proxy HTTP service is reachable."
+        exit 0
+      fi
+      sleep 2
+    done
+    echo "ERROR: llm-proxy HTTP service did not become reachable." >&2
+    exit 1
+    EOF
+    )"
 
   run_llm_proxy_e2e: |-
     bootstrap_dir="${GITHUB_WORKSPACE:-$(pwd)}/bootstrap"
@@ -268,6 +288,7 @@ pipelines:
       patch_deployment
       run_pipelines --background ci-e2e-source
       patch_agents_orchestrator
+      wait_llm_proxy_http
       run_llm_proxy_e2e
   ci-e2e-source:
     run: |-

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -167,14 +168,14 @@ func (h *Handler) forwardResponse(w http.ResponseWriter, req *http.Request, meta
 	log.Printf("proxy: upstream response status=%d", resp.StatusCode)
 	defer closeResponseBody(resp.Body)
 
-	body, err := io.ReadAll(resp.Body)
+	body, responseHeaders, err := readProviderResponse(resp)
 	if err != nil {
 		h.recordMetering(meta, nil, meteringStatusFailed)
 		writeProxyError(w, fmt.Errorf("read response: %w", err))
 		return
 	}
 
-	copyHeaders(w.Header(), resp.Header, nil)
+	copyHeaders(w.Header(), responseHeaders, nil)
 	w.WriteHeader(resp.StatusCode)
 	if _, err := w.Write(body); err != nil {
 		log.Printf("proxy: forward response failed: %v", err)
@@ -418,11 +419,31 @@ func shouldStripProviderRequestHeader(key string, connectionHeaders map[string]s
 	}
 
 	switch canonical {
-	case "Host", "Content-Length", "Connection", "Transfer-Encoding", "Keep-Alive", "Te", "Trailer", "Upgrade", "Authorization", "X-Api-Key":
+	case "Host", "Content-Length", "Connection", "Transfer-Encoding", "Keep-Alive", "Te", "Trailer", "Upgrade", "Authorization", "X-Api-Key", "Accept-Encoding":
 		return true
 	default:
 		return false
 	}
+}
+
+func readProviderResponse(resp *http.Response) ([]byte, http.Header, error) {
+	headers := resp.Header.Clone()
+	reader := resp.Body
+	if strings.EqualFold(strings.TrimSpace(resp.Header.Get("Content-Encoding")), "gzip") {
+		gzipReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("decode gzip response: %w", err)
+		}
+		defer closeResponseBody(gzipReader)
+		reader = gzipReader
+		headers.Del("Content-Encoding")
+		headers.Del("Content-Length")
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, headers, nil
 }
 
 func extractRawModelValue(body []byte) string {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"io"
@@ -8,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	authorizationv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/authorization/v1"
 	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
@@ -47,9 +50,14 @@ func (f *fakeAuthzClient) Check(_ context.Context, req *authorizationv1.CheckReq
 	return f.resp, nil
 }
 
-type fakeMeteringClient struct{}
+type fakeMeteringClient struct {
+	records chan []*meteringv1.UsageRecord
+}
 
-func (f *fakeMeteringClient) Record(_ context.Context, _ *meteringv1.RecordRequest, _ ...grpc.CallOption) (*meteringv1.RecordResponse, error) {
+func (f *fakeMeteringClient) Record(_ context.Context, req *meteringv1.RecordRequest, _ ...grpc.CallOption) (*meteringv1.RecordResponse, error) {
+	if f.records != nil {
+		f.records <- req.GetRecords()
+	}
 	return &meteringv1.RecordResponse{}, nil
 }
 
@@ -148,6 +156,107 @@ func TestHandlerForwardNonStream(t *testing.T) {
 	if authzClient.lastReq.GetTupleKey().GetObject() != "model:"+modelID.String() {
 		t.Fatalf("unexpected authz object %q", authzClient.lastReq.GetTupleKey().GetObject())
 	}
+}
+
+func TestHandlerForwardNonStreamGzipProviderResponse(t *testing.T) {
+	modelID := uuid.New()
+	responseBody := []byte(`{"id":"resp-1","usage":{"input_tokens":12,"cached_tokens":3,"output_tokens":4}}`)
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertProviderRequestHeaderAbsent(t, r.Header, "Accept-Encoding")
+
+		var compressed bytes.Buffer
+		gzipWriter := gzip.NewWriter(&compressed)
+		if _, err := gzipWriter.Write(responseBody); err != nil {
+			t.Fatalf("write gzip response: %v", err)
+		}
+		if err := gzipWriter.Close(); err != nil {
+			t.Fatalf("close gzip response: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	defer provider.Close()
+
+	client := provider.Client()
+	client.Transport = &http.Transport{DisableCompression: true}
+	meteringClient := &fakeMeteringClient{records: make(chan []*meteringv1.UsageRecord, 1)}
+	llmClient := &fakeLLMClient{resp: &llmv1.ResolveModelResponse{
+		Endpoint:       provider.URL + "/responses",
+		Token:          "provider-token",
+		RemoteName:     "remote-model",
+		OrganizationId: "org-1",
+		Protocol:       llmv1.Protocol_PROTOCOL_RESPONSES,
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
+	}}
+	authzClient := &fakeAuthzClient{resp: &authorizationv1.CheckResponse{Allowed: true}}
+	handler := NewHandler(llmClient, authzClient, meteringClient, client)
+
+	body := `{"model":"` + modelID.String() + `","stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/responses", strings.NewReader(body))
+	req.Header.Set("Accept-Encoding", "gzip")
+	ctx := identity.WithIdentity(req.Context(), identity.ResolvedIdentity{IdentityID: "user-1", IdentityType: identity.IdentityTypeUser})
+	req = req.WithContext(ctx)
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+	if strings.TrimSpace(resp.Body.String()) != string(responseBody) {
+		t.Fatalf("unexpected response body: %s", resp.Body.String())
+	}
+	if encoding := resp.Header().Get("Content-Encoding"); encoding != "" {
+		t.Fatalf("expected content-encoding to be omitted, got %q", encoding)
+	}
+	if length := resp.Header().Get("Content-Length"); length != "" {
+		t.Fatalf("expected content-length to be omitted, got %q", length)
+	}
+
+	records := readMeteringRecords(t, meteringClient.records)
+	counts := recordKinds(records)
+	if counts[meteringKindInput] != 1 {
+		t.Fatalf("expected input usage record, got %d", counts[meteringKindInput])
+	}
+	if counts[meteringKindCached] != 1 {
+		t.Fatalf("expected cached usage record, got %d", counts[meteringKindCached])
+	}
+	if counts[meteringKindOutput] != 1 {
+		t.Fatalf("expected output usage record, got %d", counts[meteringKindOutput])
+	}
+	if counts[meteringKindRequest] != 1 {
+		t.Fatalf("expected request usage record, got %d", counts[meteringKindRequest])
+	}
+	assertMeteringRecordValue(t, records, meteringKindInput, 12*meteringMicroUnits)
+	assertMeteringRecordValue(t, records, meteringKindCached, 3*meteringMicroUnits)
+	assertMeteringRecordValue(t, records, meteringKindOutput, 4*meteringMicroUnits)
+}
+
+func readMeteringRecords(t *testing.T, records chan []*meteringv1.UsageRecord) []*meteringv1.UsageRecord {
+	t.Helper()
+	select {
+	case received := <-records:
+		return received
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for metering records")
+		return nil
+	}
+}
+
+func assertMeteringRecordValue(t *testing.T, records []*meteringv1.UsageRecord, kind string, value int64) {
+	t.Helper()
+	for _, record := range records {
+		if record.Labels["kind"] == kind {
+			if record.Value != value {
+				t.Fatalf("expected %s value %d, got %d", kind, value, record.Value)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing %s record", kind)
 }
 
 func TestHandlerAuthorizesAgentWithIdentityPrincipal(t *testing.T) {

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -30,7 +30,7 @@ const (
 	defaultUsersAddr         = "users:50051"
 	defaultOrganizationsAddr = "organizations:50051"
 	defaultAuthorizationAddr = "authorization:50051"
-	defaultGatewayBaseURL    = "http://gateway-gateway.platform.svc.cluster.local:8080"
+	defaultGatewayBaseURL    = "http://gateway.platform.svc.cluster.local:8080"
 	setupTimeout             = 30 * time.Second
 	apiTokenName             = "e2e-llm-proxy"
 	llmProviderEndpoint      = "https://testllm.dev/v1/org/agynio/suite/agn/responses"


### PR DESCRIPTION
## Summary
- Strip caller `Accept-Encoding` before forwarding provider requests so Go transport can manage decompression normally.
- Decode gzip provider responses explicitly before forwarding and metering when `Content-Encoding: gzip` is present.
- Remove stale `Content-Encoding` and `Content-Length` headers after decoding so clients receive a consistent body/header pair.
- Add a `/v1/responses` regression test for caller `Accept-Encoding: gzip`, gzip provider JSON, decoded client response, and generated usage records.

Closes #67.

## Test & Lint Summary
- `go test ./internal/proxy -run 'TestHandlerForwardNonStreamGzipProviderResponse|TestHandlerForwardResponsesHeaders|TestHandlerForwardNonStream' -count=1`: passed.
- `go test ./...`: 45 passed, 0 failed, 0 skipped.
- `go vet ./...`: passed with no errors.
- `go build ./...`: passed.