### PR TITLE
fix(ziti): terminate when the overlay identity is lost

### DIFF
--- a/cmd/llm-proxy/main.go
+++ b/cmd/llm-proxy/main.go
@@ -147,7 +147,11 @@ func run() error {
 		}
 		defer zitiManager.Close()
 
-		go zitiManager.RunLeaseRenewal(ctx)
+		go func() {
+			if err := zitiManager.RunLeaseRenewal(ctx); err != nil {
+				log.Fatalf("terminating: %v", err)
+			}
+		}()
 	}
 
 	select {

--- a/internal/zitimanager/manager.go
+++ b/internal/zitimanager/manager.go
@@ -24,6 +24,11 @@ const (
 	retryUnlimited      = 0
 )
 
+// ErrIdentityLost reports that the service's OpenZiti identity no longer
+// exists (garbage-collected while the pod was running). Recovery is a pod
+// restart: a fresh pod enrolls a fresh identity.
+var ErrIdentityLost = errors.New("ziti identity lost")
+
 var (
 	errIdentityNotFound = errors.New("ziti identity not found")
 	newZitiContext      = ziti.NewContext
@@ -43,11 +48,6 @@ type Manager struct {
 
 	listenerFactory ListenerFactory
 	onNewListener   OnNewListener
-
-	reEnrollMu     sync.Mutex
-	reEnrollWait   chan struct{}
-	reEnrollActive bool
-	reEnrollErr    error
 }
 
 func New(
@@ -97,31 +97,36 @@ func New(
 	return manager, nil
 }
 
-func (m *Manager) RunLeaseRenewal(ctx context.Context) {
+// RunLeaseRenewal extends the identity lease until ctx is cancelled (returns
+// nil) or the identity is definitively gone (returns an error wrapping
+// ErrIdentityLost). Identity loss is fatal by design: the caller must log the
+// error and terminate so the pod restart path enrolls a fresh identity.
+// Transient extension failures are retried with backoff and logged.
+func (m *Manager) RunLeaseRenewal(ctx context.Context) error {
 	ticker := time.NewTicker(m.renewalInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-ticker.C:
 		}
 
 		if ctx.Err() != nil {
-			return
+			return nil
 		}
 
 		err := m.extendLease(ctx)
 		switch {
 		case err == nil:
 			continue
+		case ctx.Err() != nil:
+			return nil
 		case errors.Is(err, errIdentityNotFound):
-			if enrollErr := m.reEnroll(ctx); enrollErr != nil {
-				log.Printf("failed to re-enroll ziti identity: %v", enrollErr)
-			}
+			return fmt.Errorf("%w: identity %s no longer exists", ErrIdentityLost, m.currentIdentityID())
 		default:
-			log.Printf("failed to extend ziti lease: %v", err)
+			log.Printf("failed to extend ziti lease for identity %s: %v", m.currentIdentityID(), err)
 		}
 	}
 }
@@ -173,47 +178,6 @@ func (m *Manager) extendLease(ctx context.Context) error {
 	return err
 }
 
-func (m *Manager) reEnroll(ctx context.Context) error {
-	waitCh, leader := m.startReEnroll()
-	if !leader {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-waitCh:
-			return m.reEnrollResult()
-		}
-	}
-
-	err := m.performReEnroll(ctx)
-	m.finishReEnroll(err)
-	return err
-}
-
-func (m *Manager) performReEnroll(ctx context.Context) error {
-	m.mu.Lock()
-	oldCtx := m.zitiCtx
-	m.zitiCtx = nil
-	m.identityID = ""
-	m.mu.Unlock()
-
-	if oldCtx != nil {
-		oldCtx.Close()
-	}
-
-	zitiCtx, identityID, listener, err := m.enroll(ctx)
-	if err != nil {
-		return err
-	}
-
-	m.mu.Lock()
-	m.zitiCtx = zitiCtx
-	m.identityID = identityID
-	m.mu.Unlock()
-
-	m.onNewListener(listener)
-	return nil
-}
-
 func (m *Manager) enroll(ctx context.Context) (ziti.Context, string, net.Listener, error) {
 	enrollCtx, cancel := context.WithTimeout(ctx, m.enrollTimeout)
 	defer cancel()
@@ -252,32 +216,6 @@ func (m *Manager) currentIdentityID() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.identityID
-}
-
-func (m *Manager) startReEnroll() (<-chan struct{}, bool) {
-	m.reEnrollMu.Lock()
-	defer m.reEnrollMu.Unlock()
-	if m.reEnrollActive {
-		return m.reEnrollWait, false
-	}
-	waitCh := make(chan struct{})
-	m.reEnrollWait = waitCh
-	m.reEnrollActive = true
-	return waitCh, true
-}
-
-func (m *Manager) finishReEnroll(err error) {
-	m.reEnrollMu.Lock()
-	defer m.reEnrollMu.Unlock()
-	m.reEnrollErr = err
-	m.reEnrollActive = false
-	close(m.reEnrollWait)
-}
-
-func (m *Manager) reEnrollResult() error {
-	m.reEnrollMu.Lock()
-	defer m.reEnrollMu.Unlock()
-	return m.reEnrollErr
 }
 
 func retryWithBackoff(ctx context.Context, operationName string, isRetryable func(error) bool, maxAttempts int, fn func(context.Context) error) error {

--- a/internal/zitimanager/manager_test.go
+++ b/internal/zitimanager/manager_test.go
@@ -3,8 +3,8 @@ package zitimanager
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -216,39 +216,31 @@ func TestManagerInitialEnrollment(t *testing.T) {
 	}
 }
 
-func TestManagerReEnrollsOnNotFound(t *testing.T) {
-	tracker := stubContexts(t)
+func TestRunLeaseRenewalReturnsIdentityLostOnNotFound(t *testing.T) {
+	stubContexts(t)
 
 	identityJSON := []byte(`{}`)
-	var requestCalls atomic.Int32
 	var extendCalls atomic.Int32
 	server := &fakeZitiMgmtServer{
 		requestIdentity: func(_ context.Context, _ *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-			call := requestCalls.Add(1)
 			return &zitimgmtv1.RequestServiceIdentityResponse{
-				ZitiIdentityId: fmt.Sprintf("identity-%d", call),
+				ZitiIdentityId: "identity-1",
 				IdentityJson:   identityJSON,
 			}, nil
 		},
 		extendIdentityLease: func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
-			call := extendCalls.Add(1)
-			if call == 1 {
-				return nil, status.Error(codes.NotFound, "missing")
-			}
-			return &zitimgmtv1.ExtendIdentityLeaseResponse{}, nil
+			extendCalls.Add(1)
+			return nil, status.Error(codes.NotFound, "missing")
 		},
 	}
 
 	client, cleanup := startMgmtClient(t, server)
 	defer cleanup()
 
-	var listenerCalls atomic.Int32
 	listenerFactory := func(ziti.Context) (net.Listener, error) {
 		return &stubListener{}, nil
 	}
-	onNewListener := func(net.Listener) {
-		listenerCalls.Add(1)
-	}
+	onNewListener := func(net.Listener) {}
 
 	manager, err := New(
 		context.Background(),
@@ -263,127 +255,35 @@ func TestManagerReEnrollsOnNotFound(t *testing.T) {
 		t.Fatalf("create manager: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-	defer cancel()
-	go manager.RunLeaseRenewal(ctx)
-
-	waitForCondition(t, 200*time.Millisecond, func() bool {
-		return listenerCalls.Load() >= 2
-	}, "listener rebinding")
-
-	if requestCalls.Load() < 2 {
-		t.Fatalf("expected re-enrollment request, got %d", requestCalls.Load())
-	}
-	if manager.currentIdentityID() != "identity-2" {
-		t.Fatalf("expected identity to re-enroll, got %q", manager.currentIdentityID())
-	}
-	contexts := tracker.all()
-	if len(contexts) < 2 {
-		t.Fatalf("expected new context on re-enroll, got %d", len(contexts))
-	}
-	if !contexts[0].closed.Load() {
-		t.Fatal("expected previous ziti context to be closed")
-	}
-}
-
-func TestManagerReEnrollDebouncesConcurrentCalls(t *testing.T) {
-	tracker := stubContexts(t)
-
-	identityJSON := []byte(`{}`)
-	var requestCalls atomic.Int32
-	server := &fakeZitiMgmtServer{
-		requestIdentity: func(_ context.Context, _ *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-			call := requestCalls.Add(1)
-			return &zitimgmtv1.RequestServiceIdentityResponse{
-				ZitiIdentityId: fmt.Sprintf("identity-%d", call),
-				IdentityJson:   identityJSON,
-			}, nil
-		},
-		extendIdentityLease: func(context.Context, *zitimgmtv1.ExtendIdentityLeaseRequest) (*zitimgmtv1.ExtendIdentityLeaseResponse, error) {
-			return &zitimgmtv1.ExtendIdentityLeaseResponse{}, nil
-		},
-	}
-
-	client, cleanup := startMgmtClient(t, server)
-	defer cleanup()
-
-	var listenerCalls atomic.Int32
-	listenerFactory := func(ziti.Context) (net.Listener, error) {
-		return &stubListener{}, nil
-	}
-	onNewListener := func(net.Listener) {
-		listenerCalls.Add(1)
-	}
-
-	manager, err := New(
-		context.Background(),
-		client,
-		zitimgmtv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
-		time.Minute,
-		time.Second,
-		listenerFactory,
-		onNewListener,
-	)
-	if err != nil {
-		t.Fatalf("create manager: %v", err)
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	errCh := make(chan error, 5)
-	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			errCh <- manager.reEnroll(ctx)
-		}()
-	}
+	errCh := make(chan error, 1)
 	go func() {
-		wg.Wait()
-		close(errCh)
+		errCh <- manager.RunLeaseRenewal(ctx)
 	}()
 
-	for err := range errCh {
-		if err != nil {
-			t.Fatalf("unexpected re-enroll error: %v", err)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrIdentityLost) {
+			t.Fatalf("expected ErrIdentityLost, got %v", err)
 		}
-	}
-
-	if requestCalls.Load() != 2 {
-		t.Fatalf("expected single re-enroll, got %d", requestCalls.Load())
-	}
-	if listenerCalls.Load() != 2 {
-		t.Fatalf("expected listener rebinding once, got %d", listenerCalls.Load())
-	}
-	contexts := tracker.all()
-	if len(contexts) != 2 {
-		t.Fatalf("expected two contexts after re-enroll, got %d", len(contexts))
+		if !strings.Contains(err.Error(), "identity-1") {
+			t.Fatalf("expected error to name the lost identity, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected RunLeaseRenewal to return identity loss")
 	}
 }
 
-func TestManagerReEnrollAfterFailure(t *testing.T) {
-	tracker := stubContexts(t)
+func TestRunLeaseRenewalReturnsNilOnContextCancel(t *testing.T) {
+	stubContexts(t)
 
 	identityJSON := []byte(`{}`)
-	var requestCalls atomic.Int32
-	var failNext atomic.Bool
-	failNext.Store(true)
 	server := &fakeZitiMgmtServer{
 		requestIdentity: func(_ context.Context, _ *zitimgmtv1.RequestServiceIdentityRequest) (*zitimgmtv1.RequestServiceIdentityResponse, error) {
-			call := requestCalls.Add(1)
-			if call == 1 {
-				return &zitimgmtv1.RequestServiceIdentityResponse{
-					ZitiIdentityId: "identity-1",
-					IdentityJson:   identityJSON,
-				}, nil
-			}
-			if failNext.Load() {
-				return nil, status.Error(codes.Unavailable, "boom")
-			}
 			return &zitimgmtv1.RequestServiceIdentityResponse{
-				ZitiIdentityId: "identity-2",
+				ZitiIdentityId: "identity-1",
 				IdentityJson:   identityJSON,
 			}, nil
 		},
@@ -395,19 +295,16 @@ func TestManagerReEnrollAfterFailure(t *testing.T) {
 	client, cleanup := startMgmtClient(t, server)
 	defer cleanup()
 
-	var listenerCalls atomic.Int32
 	listenerFactory := func(ziti.Context) (net.Listener, error) {
 		return &stubListener{}, nil
 	}
-	onNewListener := func(net.Listener) {
-		listenerCalls.Add(1)
-	}
+	onNewListener := func(net.Listener) {}
 
 	manager, err := New(
 		context.Background(),
 		client,
 		zitimgmtv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
-		time.Minute,
+		5*time.Millisecond,
 		time.Second,
 		listenerFactory,
 		onNewListener,
@@ -416,32 +313,20 @@ func TestManagerReEnrollAfterFailure(t *testing.T) {
 		t.Fatalf("create manager: %v", err)
 	}
 
-	failedCtx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- manager.RunLeaseRenewal(ctx)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
 
-	if err := manager.reEnroll(failedCtx); err == nil {
-		t.Fatal("expected re-enroll to fail")
-	}
-	if listenerCalls.Load() != 1 {
-		t.Fatalf("expected no listener rebinding on failure, got %d", listenerCalls.Load())
-	}
-
-	failNext.Store(false)
-
-	successCtx, cancelSuccess := context.WithTimeout(context.Background(), time.Second)
-	defer cancelSuccess()
-
-	if err := manager.reEnroll(successCtx); err != nil {
-		t.Fatalf("expected re-enroll success, got %v", err)
-	}
-	if listenerCalls.Load() != 2 {
-		t.Fatalf("expected listener rebinding after recovery, got %d", listenerCalls.Load())
-	}
-	if manager.currentIdentityID() != "identity-2" {
-		t.Fatalf("expected identity-2 after recovery, got %q", manager.currentIdentityID())
-	}
-	contexts := tracker.all()
-	if len(contexts) < 2 {
-		t.Fatalf("expected new context after recovery, got %d", len(contexts))
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("expected nil on context cancel, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected RunLeaseRenewal to return after cancel")
 	}
 }


### PR DESCRIPTION
The manager re-enrolled in place when a lease extension returned `NOT_FOUND`.
That cannot work — the identity is ephemeral and per-pod, so once it has been
garbage-collected there is nothing left to renew and the re-enroll path just
churns.

It matters more here than elsewhere: `llm-proxy` **binds** its Ziti service, so
a lost identity means the pod stays Ready while serving nothing on the overlay.
Agents cannot reach the LLM at all, and nothing reports why.

`RunLeaseRenewal` now returns an error wrapping `ErrIdentityLost` and `main`
terminates, so the restart enrolls a fresh identity. The `reEnroll*` machinery
goes with it — 232 lines removed against 59 added.

Last of the four services to get this: `terminal-proxy`, `agents-orchestrator`
and `runners` already fail fast on identity loss.

Mutation-checked: making identity loss return `nil` fails
`TestRunLeaseRenewalReturnsIdentityLostOnNotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)