### PR TITLE
Accept agent_instance identities

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -4,26 +4,6 @@ vars:
   LLM_PROXY_NAMESPACE: platform
 
 functions:
-  disable_argocd_sync: |-
-    if kubectl get application llm-proxy -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for llm-proxy..."
-      kubectl patch application llm-proxy -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":null}}}'
-      echo "ArgoCD auto-sync disabled."
-    else
-      echo "WARNING: ArgoCD Application 'llm-proxy' not found in argocd namespace."
-    fi
-  restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application llm-proxy -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for llm-proxy..."
-      kubectl patch application llm-proxy -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-      echo "ArgoCD auto-sync restored."
-    else
-      echo "WARNING: ArgoCD Application 'llm-proxy' not found in argocd namespace."
-    fi
   patch_deployment: |-
     echo "Patching llm-proxy deployment for DevSpace..."
     # Resolve by label: the umbrella names the deployment llm-proxy and the
@@ -271,7 +251,6 @@ pipelines:
         short: w
         description: "Keep DevSpace running and stream logs"
     run: |-
-      disable_argocd_sync
       patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace llm-proxy
@@ -284,7 +263,6 @@ pipelines:
       run_llm_proxy_e2e
   ci-e2e:
     run: |-
-      disable_argocd_sync
       patch_deployment
       run_pipelines --background ci-e2e-source
       patch_agents_orchestrator
@@ -294,13 +272,6 @@ pipelines:
       start_dev --disable-pod-replace llm-proxy
 
 hooks:
-  - name: restore-argocd-auto-sync
-    events:
-      - after:dev:llm-proxy
-    command: bash
-    args:
-      - -c
-      - *restore_argocd_sync
 
 dev:
   llm-proxy:

--- a/internal/identity/agent_instance_test.go
+++ b/internal/identity/agent_instance_test.go
@@ -1,0 +1,24 @@
+package identity
+
+import "testing"
+
+// Agent workloads authenticate as agent_instance. Refusing the type here
+// refused every turn they tried to take: the LLM proxy answered 401 and codex
+// reported "identity type unsupported: IDENTITY_TYPE_AGENT_INSTANCE".
+func TestParseIdentityTypeAcceptsAgentInstance(t *testing.T) {
+	parsed, err := ParseIdentityType("agent_instance")
+	if err != nil {
+		t.Fatalf("parse agent_instance: %v", err)
+	}
+	if parsed != IdentityTypeAgentInstance {
+		t.Fatalf("expected %q, got %q", IdentityTypeAgentInstance, parsed)
+	}
+}
+
+// An instance is not a sandbox, so it must not be mistaken for one.
+func TestAgentInstanceIsNotASandbox(t *testing.T) {
+	resolved := ResolvedIdentity{IdentityID: "id", IdentityType: IdentityTypeAgentInstance}
+	if resolved.SandboxID() != "" {
+		t.Fatalf("expected no sandbox id, got %q", resolved.SandboxID())
+	}
+}

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -9,11 +9,17 @@ import (
 type IdentityType string
 
 const (
-	IdentityTypeUser    IdentityType = "user"
-	IdentityTypeAgent   IdentityType = "agent"
-	IdentityTypeApp     IdentityType = "app"
-	IdentityTypeRunner  IdentityType = "runner"
-	IdentityTypeSandbox IdentityType = "sandbox"
+	IdentityTypeUser IdentityType = "user"
+	// IdentityTypeAgent names an agent class. It predates instances and is kept
+	// because identities minted before the migration still present it.
+	IdentityTypeAgent IdentityType = "agent"
+	// IdentityTypeAgentInstance names one running instance of an agent class.
+	// Agent workloads authenticate as this, so refusing it here refused every
+	// turn they tried to take.
+	IdentityTypeAgentInstance IdentityType = "agent_instance"
+	IdentityTypeApp           IdentityType = "app"
+	IdentityTypeRunner        IdentityType = "runner"
+	IdentityTypeSandbox       IdentityType = "sandbox"
 )
 
 type ResolvedIdentity struct {
@@ -42,6 +48,8 @@ func ParseIdentityType(value string) (IdentityType, error) {
 		return IdentityTypeUser, nil
 	case string(IdentityTypeAgent):
 		return IdentityTypeAgent, nil
+	case string(IdentityTypeAgentInstance):
+		return IdentityTypeAgentInstance, nil
 	case string(IdentityTypeApp):
 		return IdentityTypeApp, nil
 	case string(IdentityTypeRunner):

--- a/internal/zitimgmtclient/client.go
+++ b/internal/zitimgmtclient/client.go
@@ -108,6 +108,8 @@ func parseIdentityType(identityType identityv1.IdentityType) (identity.IdentityT
 	switch identityType {
 	case identityv1.IdentityType_IDENTITY_TYPE_AGENT:
 		return identity.IdentityTypeAgent, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_AGENT_INSTANCE:
+		return identity.IdentityTypeAgentInstance, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
 		return identity.IdentityTypeRunner, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_APP:


### PR DESCRIPTION
Agent workloads authenticate as `agent_instance`, and the LLM proxy refused the type outright — every turn came back 401:

```
unexpected status 401 Unauthorized: identity type unsupported: IDENTITY_TYPE_AGENT_INSTANCE,
url: http://llm-proxy.ziti/v1/responses
```

The Gateway gained this in agynio/gateway#197; this is the same gap on the LLM path.