### PR TITLE
Pin the path the native forwarder sends upstream

### DIFF
--- a/internal/proxy/native_test.go
+++ b/internal/proxy/native_test.go
@@ -285,3 +285,32 @@ func readAllBody(r *http.Request) ([]byte, error) {
 		}
 	}
 }
+
+// The caller's whole path is appended to the upstream, so an upstream that
+// carries a path of its own forwards it twice -- which reaches the vendor as a
+// 404 and looks like the endpoint does not exist.
+func TestNativeForwardPreservesTheCallersPathExactly(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"gpt-5.5","usage":{}}`))
+	}))
+	defer upstream.Close()
+
+	binding := nativeBinding(upstream.URL)
+	binding.Vendor = llmv1.Vendor_VENDOR_OPENAI
+	binding.Protocol = llmv1.Protocol_PROTOCOL_RESPONSES
+
+	forwarder := NewNativeForwarder(upstream.Client(), newCapturingMeteringClient())
+
+	recorder := httptest.NewRecorder()
+	forwarder.Forward(recorder, nativeRequest(t, "/backend-api/codex/responses", `{"model":"gpt-5.5"}`), binding)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if gotPath != "/backend-api/codex/responses" {
+		t.Fatalf("upstream path = %q, want the caller's own", gotPath)
+	}
+}


### PR DESCRIPTION
Regression test for the composition in `buildRequest`:

```go
target := strings.TrimSuffix(binding.UpstreamEndpoint, "/") + r.URL.RequestURI()
```

The caller's whole path is appended, so an upstream that carries a path of its own sends it twice. That is what made codex's `/backend-api/codex/responses` arrive as `/backend-api/codex/backend-api/codex/responses` and come back 404 — which reads as a missing endpoint rather than a bug here. Fixed on the binding side in [llm#56](https://github.com/agynio/llm/pull/56); this stops it recurring silently.