### PR TITLE
Name the overlay .agyn, not .ziti

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -90,7 +90,7 @@ functions:
   patch_agents_orchestrator: |-
     echo "Patching agents-orchestrator to target llm-proxy over Ziti..."
     kubectl set env deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} \
-      AGENT_LLM_BASE_URL=http://llm-proxy.ziti/v1
+      AGENT_LLM_BASE_URL=http://llm-proxy.agyn/v1
     kubectl rollout status deployment/agents-orchestrator -n ${LLM_PROXY_NAMESPACE} --timeout=120s
 
   run_llm_proxy_e2e: |-


### PR DESCRIPTION
Renames the LLM base URL in the devspace config to match the overlay rename landing across the platform: `llm-proxy.ziti` becomes `llm-proxy.agyn`.

Devspace config only — no service code changes.