### PR TITLE
Label which agent, instance and environment a call was for

### DIFF
--- a/internal/proxy/metering.go
+++ b/internal/proxy/metering.go
@@ -31,6 +31,13 @@ const (
 	meteringLabelSandboxID      = "sandbox_id"
 	meteringLabelSandboxOwnerID = "sandbox_owner_id"
 
+	// The levels usage is ranked by. identity_id names whichever one
+	// authenticated, which is the instance here and the class in the
+	// Orchestrator's records; these name themselves.
+	meteringLabelAgentID         = "agent_id"
+	meteringLabelAgentInstanceID = "agent_instance_id"
+	meteringLabelEnvironmentID   = "environment_id"
+
 	// resource is a resource *type*, which is what keeps native-mode tokens out
 	// of spend aggregation: a subscription is a flat fee, and summing its
 	// tokens alongside API tokens produces a bill that does not exist.
@@ -221,14 +228,21 @@ func buildUsageRecords(meta meteringMetadata, usage *usageCounts, status string)
 		baseLabels["vendor"] = meta.vendor
 		baseLabels["model_name"] = meta.modelName
 	}
-	// Usage a sandbox runs up is the organization's to pay for, but the
-	// organization alone does not say who to ask about it. The sandbox and its
-	// owner are labelled the way the Orchestrator labels the sandbox's compute,
-	// so both halves of a sandbox's cost line up under the same names.
-	if meta.sandbox.isSandbox() {
-		baseLabels[meteringLabelSandboxID] = meta.sandbox.sandboxID
-		baseLabels[meteringLabelSandboxOwnerID] = meta.sandbox.ownerID
+	// Which agent, which instance of it, and which environment. The OpenZiti
+	// identity carries all three, so a call stays attributable without joining
+	// a workload record that may already be gone.
+	setLabelIfPresent(baseLabels, meteringLabelAgentID, meta.identity.AgentID)
+	setLabelIfPresent(baseLabels, meteringLabelEnvironmentID, meta.identity.EnvironmentID)
+	if meta.identity.IdentityType == identity.IdentityTypeAgentInstance {
+		setLabelIfPresent(baseLabels, meteringLabelAgentInstanceID, meta.identity.IdentityID)
 	}
+
+	// Usage a sandbox runs up is the organization's to pay for, but the
+	// organization alone does not say who to ask about it. The sandbox is read
+	// off the identity -- a sandbox authenticates as itself -- so native mode
+	// labels it too, having no record to resolve; only the owner needs one.
+	setLabelIfPresent(baseLabels, meteringLabelSandboxID, meta.identity.SandboxID())
+	setLabelIfPresent(baseLabels, meteringLabelSandboxOwnerID, meta.sandbox.ownerID)
 
 	records := make([]*meteringv1.UsageRecord, 0, 4)
 
@@ -258,6 +272,15 @@ func newUsageRecord(meta meteringMetadata, timestamp *timestamppb.Timestamp, uni
 		Labels:         labels,
 		Unit:           unit,
 		Value:          value,
+	}
+}
+
+// setLabelIfPresent keeps absent levels out of the map entirely. Metering drops
+// empty values anyway; not writing them keeps the labels a record carries the
+// same list a reader can expect to group by.
+func setLabelIfPresent(labels map[string]string, key, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		labels[key] = trimmed
 	}
 }
 

--- a/internal/proxy/metering_test.go
+++ b/internal/proxy/metering_test.go
@@ -5,6 +5,7 @@ import (
 
 	llmv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/llm/v1"
 	meteringv1 "github.com/agynio/llm-proxy/.gen/go/agynio/api/metering/v1"
+	"github.com/agynio/llm-proxy/internal/identity"
 )
 
 func TestParseUsageFromPayloadOpenAIUsage(t *testing.T) {
@@ -228,4 +229,67 @@ func recordKinds(records []*meteringv1.UsageRecord) map[string]int {
 		counts[record.Labels["kind"]]++
 	}
 	return counts
+}
+
+// The Usage page ranks spend by instance, by agent, and by environment. The
+// OpenZiti identity is the only place a call carries all three, so a record
+// built without them can only be attributed to "unknown".
+func TestBuildUsageRecordsLabelsWorkloadLevels(t *testing.T) {
+	meta := meteringMetadata{
+		callID:  "call-1",
+		orgID:   "org-1",
+		modelID: "model-1",
+		identity: identity.ResolvedIdentity{
+			IdentityID:    "instance-1",
+			IdentityType:  identity.IdentityTypeAgentInstance,
+			AgentID:       "agent-1",
+			EnvironmentID: "environment-1",
+		},
+	}
+
+	records := buildUsageRecords(meta, nil, meteringStatusSuccess)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	labels := records[0].Labels
+	for key, want := range map[string]string{
+		meteringLabelAgentID:         "agent-1",
+		meteringLabelAgentInstanceID: "instance-1",
+		meteringLabelEnvironmentID:   "environment-1",
+	} {
+		if labels[key] != want {
+			t.Errorf("label %s = %q, want %q", key, labels[key], want)
+		}
+	}
+	if _, ok := labels[meteringLabelSandboxID]; ok {
+		t.Errorf("an instance is not a sandbox, got sandbox_id=%q", labels[meteringLabelSandboxID])
+	}
+}
+
+// Native mode resolves no sandbox record, so a sandbox's tokens were recorded
+// with nothing naming the sandbox. The identity already is the sandbox.
+func TestBuildUsageRecordsLabelsSandboxWithoutAResolvedRecord(t *testing.T) {
+	meta := meteringMetadata{
+		callID:  "call-1",
+		orgID:   "org-1",
+		modelID: "subscription-1",
+		native:  true,
+		identity: identity.ResolvedIdentity{
+			IdentityID:    "sandbox-1",
+			IdentityType:  identity.IdentityTypeSandbox,
+			EnvironmentID: "environment-1",
+		},
+	}
+
+	records := buildUsageRecords(meta, nil, meteringStatusSuccess)
+	labels := records[0].Labels
+	if labels[meteringLabelSandboxID] != "sandbox-1" {
+		t.Fatalf("sandbox_id = %q, want sandbox-1", labels[meteringLabelSandboxID])
+	}
+	if labels[meteringLabelEnvironmentID] != "environment-1" {
+		t.Fatalf("environment_id = %q, want environment-1", labels[meteringLabelEnvironmentID])
+	}
+	if _, ok := labels[meteringLabelAgentInstanceID]; ok {
+		t.Errorf("a sandbox is not an instance, got agent_instance_id=%q", labels[meteringLabelAgentInstanceID])
+	}
 }


### PR DESCRIPTION
`identity_id` names whichever principal authenticated — the instance here, the class in the Orchestrator's records — so neither side alone ranks a class beside an instance. The OpenZiti identity already carries the agent, the instance and the environment, so a call stays attributable without joining a workload record that may already be gone.

Also fixes a real gap: `sandbox_id` is now read off the identity rather than the resolved sandbox record. A sandbox authenticates as itself, and the native path resolves no record, so **every native-mode sandbox call has been metered with nothing naming the sandbox** since sandboxes could call models — 268 such rows in the local VM. Only `sandbox_owner_id` still needs the record.

Verified live in the VM: a native-mode sandbox call now lands with `sandbox_id` and `environment_id` set, and with `agent_id`/`agent_instance_id` correctly absent.