### PR TITLE
Say why the provider refused

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  LLM_PROXY_NAMESPACE: platform
+  LLM_PROXY_NAMESPACE: agyn-platform
 
 functions:
   patch_deployment: |-
@@ -304,5 +304,3 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "8080"

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -192,6 +192,7 @@ func (h *Handler) forwardResponse(w http.ResponseWriter, req *http.Request, meta
 	}
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		logUpstreamRefusal(resp.StatusCode, body)
 		h.recordMetering(meta, nil, meteringStatusFailed)
 		return
 	}
@@ -203,6 +204,28 @@ func (h *Handler) forwardResponse(w http.ResponseWriter, req *http.Request, meta
 		return
 	}
 	h.recordMetering(meta, &usage, meteringStatusSuccess)
+}
+
+// logUpstreamRefusal records why a provider refused a call.
+//
+// The status alone answers nothing: "upstream response status=400" is the same
+// line whether the model is unknown, the key is wrong, or the request is
+// malformed, and the body is the only place the provider says which. It is
+// bounded because a provider that answers 400 with a page of HTML should not
+// fill the log with it, and it is only read on a refusal, so a successful
+// call's body -- which carries what the model said -- is never logged.
+func logUpstreamRefusal(status int, body []byte) {
+	const maxLoggedBody = 2048
+	if len(body) == 0 {
+		return
+	}
+	snippet := body
+	truncated := ""
+	if len(snippet) > maxLoggedBody {
+		snippet = snippet[:maxLoggedBody]
+		truncated = "..."
+	}
+	log.Printf("proxy: upstream refused status=%d body=%s%s", status, strings.TrimSpace(string(snippet)), truncated)
 }
 
 func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *http.Request, protocol llmv1.Protocol, meta meteringMetadata) {
@@ -218,7 +241,12 @@ func (h *Handler) streamResponse(w http.ResponseWriter, r *http.Request, req *ht
 	copyHeaders(w.Header(), resp.Header, map[string]struct{}{"Content-Length": {}})
 	w.WriteHeader(resp.StatusCode)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		_, _ = io.Copy(w, resp.Body)
+		failure, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			log.Printf("proxy: read upstream refusal: %v", readErr)
+		}
+		logUpstreamRefusal(resp.StatusCode, failure)
+		_, _ = w.Write(failure)
 		h.recordMetering(meta, nil, meteringStatusFailed)
 		return
 	}


### PR DESCRIPTION
`proxy: upstream response status=400` is the same line whether the model is unknown, the key is wrong, or the request is malformed. The provider explains itself in the body — which the proxy reads, forwards to the caller, and logs none of.

Finding out therefore meant going and asking the *agent* what it had been told, several layers away from the service that already had the answer in hand. This logs it: on a refusal only, so a successful call's body — which carries what the model said — never reaches a log, and bounded so a provider answering 400 with a page of HTML cannot fill one.

It paid for itself immediately. With it, the claude e2e failure reads straight out of the proxy log: TestLLM refuses the request because `messages[1].role` is `system`, and the Anthropic Messages API takes only `user`/`assistant` there.

Two things found by running this from source, both already known to the wider platform:

- `LLM_PROXY_NAMESPACE` still defaulted to `platform`, which the platform left when it moved to `agyn-platform` — `devspace dev` resolved no deployment and failed on an out-of-bounds jsonpath.
- The dev config forwarded a host port. That is not part of this flow.